### PR TITLE
fix: use typed Linescore/Boxscore models in LiveData

### DIFF
--- a/src/mlb_statsapi/models/__init__.py
+++ b/src/mlb_statsapi/models/__init__.py
@@ -54,7 +54,12 @@ from mlb_statsapi.models.enums import (
     TransactionType,
     WindDirection,
 )
-from mlb_statsapi.models.game import BoxscoreResponse, LinescoreResponse
+from mlb_statsapi.models.game import (
+    Boxscore,
+    BoxscoreResponse,
+    Linescore,
+    LinescoreResponse,
+)
 from mlb_statsapi.models.hydrations import (
     PeopleHydrations,
     ScheduleHydrations,
@@ -150,6 +155,7 @@ __all__ = [
     "AwardResult",
     "AwardWinner",
     "AwardsResponse",
+    "Boxscore",
     "BoxscoreResponse",
     "Division",
     "DivisionsResponse",
@@ -164,6 +170,7 @@ __all__ = [
     "LeaderEntry",
     "League",
     "LeaguesResponse",
+    "Linescore",
     "LinescoreResponse",
     "LiveFeedResponse",
     "MetaItem",

--- a/src/mlb_statsapi/models/game.py
+++ b/src/mlb_statsapi/models/game.py
@@ -67,11 +67,12 @@ class LinescoreTeams(MlbBaseModel):
     away: LinescoreTeamTotal
 
 
-class LinescoreResponse(BaseResponse):
-    """Response from ``/api/v1/game/{gamePk}/linescore``.
+class Linescore(MlbBaseModel):
+    """Linescore data for a game.
 
     Contains the inning-by-inning breakdown and current game state
-    (current inning, half, and scheduled innings).
+    (current inning, half, and scheduled innings).  Used directly when
+    the linescore is embedded inside another response (e.g. live feed).
     """
 
     current_inning: int | None = None
@@ -93,6 +94,10 @@ class LinescoreResponse(BaseResponse):
     on_first: PersonRef | None = None
     on_second: PersonRef | None = None
     on_third: PersonRef | None = None
+
+
+class LinescoreResponse(BaseResponse, Linescore):
+    """Response from ``/api/v1/game/{gamePk}/linescore``."""
 
 
 # ---------------------------------------------------------------------------
@@ -233,11 +238,12 @@ class BoxscoreOfficial(MlbBaseModel):
     official_type: str | None = None
 
 
-class BoxscoreResponse(BaseResponse):
-    """Response from ``/api/v1/game/{gamePk}/boxscore``.
+class Boxscore(MlbBaseModel):
+    """Boxscore data for a game.
 
     Contains team-level and player-level statistics, batting orders,
-    game officials, and supplementary info sections.
+    game officials, and supplementary info sections.  Used directly
+    when the boxscore is embedded inside another response (e.g. live feed).
     """
 
     teams: BoxscoreTeams
@@ -245,3 +251,7 @@ class BoxscoreResponse(BaseResponse):
     info: list[BoxscoreInfoField] = []
     pitching_notes: list[str] = []
     top_performers: list[MlbBaseModel] = []
+
+
+class BoxscoreResponse(BaseResponse, Boxscore):
+    """Response from ``/api/v1/game/{gamePk}/boxscore``."""

--- a/src/mlb_statsapi/models/livefeed.py
+++ b/src/mlb_statsapi/models/livefeed.py
@@ -47,6 +47,7 @@ from mlb_statsapi.models.enums import (
 from mlb_statsapi.models.enums import (
     PitchType as PitchTypeEnum,
 )
+from mlb_statsapi.models.game import Boxscore, Linescore
 from mlb_statsapi.models.people import Person
 from mlb_statsapi.models.venues import Venue
 
@@ -577,10 +578,8 @@ class LiveData(MlbBaseModel):
     """
 
     plays: Plays | None = None
-    # TODO: type as LinescoreResponse once response hierarchy is refactored
-    linescore: MlbBaseModel | None = None
-    # TODO: type as BoxscoreResponse once response hierarchy is refactored
-    boxscore: MlbBaseModel | None = None
+    linescore: Linescore | None = None
+    boxscore: Boxscore | None = None
     decisions: Decisions | None = None
     leaders: MlbBaseModel | None = None
 


### PR DESCRIPTION
## Summary
- Extracts `Linescore` and `Boxscore` base models from `LinescoreResponse` and `BoxscoreResponse`, separating data fields from the `BaseResponse` wrapper (which requires `copyright`)
- `LiveData` now uses the typed `Linescore` and `Boxscore` models instead of generic `MlbBaseModel`
- `LinescoreResponse` and `BoxscoreResponse` use multiple inheritance (`BaseResponse` + base model) so standalone endpoint responses are unchanged

Closes #15

## Test plan
- [x] All 251 existing tests pass
- [x] Linting and formatting pass (ruff pre-commit hooks)
- [x] LiveFeed fixture parsing works with typed linescore/boxscore fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)