### PR TITLE
fix: use BoxscoreInfo instead of BoxscoreInfoField for Boxscore.info

### DIFF
--- a/src/mlb_statsapi/models/game.py
+++ b/src/mlb_statsapi/models/game.py
@@ -248,7 +248,7 @@ class Boxscore(MlbBaseModel):
 
     teams: BoxscoreTeams
     officials: list[BoxscoreOfficial] = []
-    info: list[BoxscoreInfoField] = []
+    info: list[BoxscoreInfo] = []
     pitching_notes: list[str] = []
     top_performers: list[MlbBaseModel] = []
 


### PR DESCRIPTION
## Summary
- Changes `Boxscore.info` from `list[BoxscoreInfoField]` to `list[BoxscoreInfo]` to match the actual API structure (titled sections, not individual label/value fields)
- Consistent with `BoxscoreTeam.info` which already uses `list[BoxscoreInfo]`

Closes #10

## Test plan
- [x] All 251 tests pass
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)