### PR TITLE
feat: validate required_params before making API calls

### DIFF
--- a/src/mlb_statsapi/client/_base.py
+++ b/src/mlb_statsapi/client/_base.py
@@ -31,6 +31,24 @@ class ClientMixin:
         self, endpoint: str, **params: Any
     ) -> tuple[str, dict[str, str]]:
         ep = self._resolve_endpoint(endpoint)
+
+        # Validate required params before making the request.
+        # required_params is a tuple of groups — at least one group must be
+        # fully satisfied (OR between groups, AND within each group).
+        # An empty group ((),) means no params are required.
+        if ep.required_params and not any(
+            all(p in params for p in group) for group in ep.required_params
+        ):
+            groups_str = " OR ".join(
+                "(" + ", ".join(g) + ")" for g in ep.required_params if g
+            )
+            raise MlbApiError(
+                0,
+                f"Missing required parameters for '{endpoint}': "
+                f"must provide {groups_str}",
+                "",
+            )
+
         # Separate path params from query params
         path_params = {
             k: str(params.pop(k))

--- a/tests/test_client/test_sync.py
+++ b/tests/test_client/test_sync.py
@@ -57,6 +57,14 @@ class TestMlbClientGet:
         with pytest.raises(MlbApiError, match="Unknown endpoint"):
             client.get("bogus_endpoint")
 
+    def test_get_missing_required_params_raises(self):
+        from mlb_statsapi.client.sync_client import MlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        client = MlbClient()
+        with pytest.raises(MlbApiError, match="Missing required parameters"):
+            client.get("standings")
+
     def test_get_http_error(self, mock_api):
         from mlb_statsapi.client.sync_client import MlbClient
         from mlb_statsapi.exceptions import MlbApiError


### PR DESCRIPTION
## Summary
- Validates `required_params` in `_build_request()` before making the HTTP call
- Raises `MlbApiError` with a clear message listing which parameter groups are needed
- At least one group must be fully satisfied (OR between groups, AND within each group)
- Added test for missing required params

Closes #5

## Test plan
- [x] All 252 tests pass (251 existing + 1 new)
- [x] Linting and formatting pass
- [x] Verified endpoints with no required_params (e.g. `sports`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)