### PR TITLE
feat: handle JSON decode errors and timeout exceptions explicitly

### DIFF
--- a/src/mlb_statsapi/client/async_client.py
+++ b/src/mlb_statsapi/client/async_client.py
@@ -45,11 +45,21 @@ class AsyncMlbClient(ClientMixin):
         try:
             resp = await self._http.get(url, params=query)
             resp.raise_for_status()
+        except httpx.TimeoutException as e:
+            raise MlbApiError(0, f"Request timed out: {e}", url) from e
         except httpx.HTTPStatusError as e:
             raise MlbApiError(e.response.status_code, str(e), url) from e
         except httpx.HTTPError as e:
             raise MlbApiError(0, str(e), url) from e
-        return self._parse_response(endpoint, resp.json())
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise MlbApiError(
+                resp.status_code,
+                f"Invalid JSON in response: {e}",
+                url,
+            ) from e
+        return self._parse_response(endpoint, data)
 
     # -- Generic access --
 

--- a/src/mlb_statsapi/client/sync_client.py
+++ b/src/mlb_statsapi/client/sync_client.py
@@ -49,11 +49,21 @@ class MlbClient(ClientMixin):
         try:
             resp = self._http.get(url, params=query)
             resp.raise_for_status()
+        except httpx.TimeoutException as e:
+            raise MlbApiError(0, f"Request timed out: {e}", url) from e
         except httpx.HTTPStatusError as e:
             raise MlbApiError(e.response.status_code, str(e), url) from e
         except httpx.HTTPError as e:
             raise MlbApiError(0, str(e), url) from e
-        return self._parse_response(endpoint, resp.json())
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise MlbApiError(
+                resp.status_code,
+                f"Invalid JSON in response: {e}",
+                url,
+            ) from e
+        return self._parse_response(endpoint, data)
 
     # -- Generic access --
 

--- a/tests/test_client/test_async.py
+++ b/tests/test_client/test_async.py
@@ -60,3 +60,29 @@ class TestAsyncMlbClient:
         async with AsyncMlbClient() as client:
             with pytest.raises(MlbApiError):
                 await client.get("sports")
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_raises(self, mock_api):
+        from mlb_statsapi.client.async_client import AsyncMlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        mock_api.get("/v1/sports").respond(
+            200, content=b"not json", headers={"content-type": "text/plain"}
+        )
+
+        async with AsyncMlbClient() as client:
+            with pytest.raises(MlbApiError, match="Invalid JSON"):
+                await client.get("sports")
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises(self, mock_api):
+        import httpx
+
+        from mlb_statsapi.client.async_client import AsyncMlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        mock_api.get("/v1/sports").mock(side_effect=httpx.ReadTimeout("timed out"))
+
+        async with AsyncMlbClient() as client:
+            with pytest.raises(MlbApiError, match="timed out"):
+                await client.get("sports")

--- a/tests/test_client/test_sync.py
+++ b/tests/test_client/test_sync.py
@@ -67,6 +67,30 @@ class TestMlbClientGet:
         with pytest.raises(MlbApiError):
             client.get("sports")
 
+    def test_get_invalid_json_raises(self, mock_api):
+        from mlb_statsapi.client.sync_client import MlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        mock_api.get("/v1/sports").respond(
+            200, content=b"not json", headers={"content-type": "text/plain"}
+        )
+
+        client = MlbClient()
+        with pytest.raises(MlbApiError, match="Invalid JSON"):
+            client.get("sports")
+
+    def test_get_timeout_raises(self, mock_api):
+        import httpx
+
+        from mlb_statsapi.client.sync_client import MlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        mock_api.get("/v1/sports").mock(side_effect=httpx.ReadTimeout("timed out"))
+
+        client = MlbClient()
+        with pytest.raises(MlbApiError, match="timed out"):
+            client.get("sports")
+
 
 class TestMlbClientConvenience:
     """Test typed convenience methods."""


### PR DESCRIPTION
## Summary
- Catches `httpx.TimeoutException` separately before the generic `HTTPError` handler with a clear "Request timed out" message
- Catches `ValueError` from `resp.json()` and wraps it in `MlbApiError` with "Invalid JSON in response" message
- Applied to both sync and async clients
- Added tests for both scenarios in both clients

Closes #6

## Test plan
- [x] All 255 tests pass (251 existing + 4 new)
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)