### PR TITLE
test: add HTTP error scenario tests (400, 404, 429, 503)

### DIFF
--- a/tests/test_client/test_async.py
+++ b/tests/test_client/test_async.py
@@ -60,3 +60,20 @@ class TestAsyncMlbClient:
         async with AsyncMlbClient() as client:
             with pytest.raises(MlbApiError):
                 await client.get("sports")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "status_code",
+        [400, 404, 429, 503],
+        ids=["bad_request", "not_found", "rate_limited", "unavailable"],
+    )
+    async def test_http_status_error(self, mock_api, status_code):
+        from mlb_statsapi.client.async_client import AsyncMlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        mock_api.get("/v1/sports").respond(status_code)
+
+        async with AsyncMlbClient() as client:
+            with pytest.raises(MlbApiError) as exc_info:
+                await client.get("sports")
+            assert exc_info.value.status_code == status_code

--- a/tests/test_client/test_sync.py
+++ b/tests/test_client/test_sync.py
@@ -68,6 +68,26 @@ class TestMlbClientGet:
             client.get("sports")
 
 
+class TestMlbClientHttpErrors:
+    """Test HTTP error status codes."""
+
+    @pytest.mark.parametrize(
+        "status_code",
+        [400, 404, 429, 500, 503],
+        ids=["bad_request", "not_found", "rate_limited", "server_error", "unavailable"],
+    )
+    def test_http_status_error(self, mock_api, status_code):
+        from mlb_statsapi.client.sync_client import MlbClient
+        from mlb_statsapi.exceptions import MlbApiError
+
+        mock_api.get("/v1/sports").respond(status_code)
+
+        client = MlbClient()
+        with pytest.raises(MlbApiError) as exc_info:
+            client.get("sports")
+        assert exc_info.value.status_code == status_code
+
+
 class TestMlbClientConvenience:
     """Test typed convenience methods."""
 


### PR DESCRIPTION
## Summary
- Adds parametrized tests for HTTP 400, 404, 429, and 503 error responses
- Verifies `MlbApiError` is raised with the correct `status_code` for each
- Added to both sync and async client test suites

Closes #8

## Test plan
- [x] All 260 tests pass (251 existing + 9 new)
- [x] Linting and formatting pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)