### PR TITLE
feat: add CLI tool for exploring API endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ classifiers = [
 ]
 dependencies = ["pydantic>=2.0", "httpx>=0.25"]
 
+[project.scripts]
+mlb-statsapi = "mlb_statsapi.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/DarkSideOfTheMat/mlb-statsapi-pydantic"
 Repository = "https://github.com/DarkSideOfTheMat/mlb-statsapi-pydantic"
@@ -32,6 +35,7 @@ Issues = "https://github.com/DarkSideOfTheMat/mlb-statsapi-pydantic/issues"
 Changelog = "https://github.com/DarkSideOfTheMat/mlb-statsapi-pydantic/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
+cli = ["rich>=13.0"]
 dev = [
   "pytest>=8.0",
   "pytest-asyncio>=0.23",

--- a/src/mlb_statsapi/__main__.py
+++ b/src/mlb_statsapi/__main__.py
@@ -1,0 +1,5 @@
+"""Allow ``python -m mlb_statsapi`` to launch the CLI."""
+
+from mlb_statsapi.cli import main
+
+raise SystemExit(main())

--- a/src/mlb_statsapi/cli.py
+++ b/src/mlb_statsapi/cli.py
@@ -1,0 +1,197 @@
+"""CLI entry point for exploring MLB Stats API endpoints.
+
+Usage::
+
+    mlb-statsapi schedule date=07/01/2024
+    mlb-statsapi game gamePk=745570 --output py
+    mlb-statsapi --list-endpoints
+    mlb-statsapi schedule --help-endpoint
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pprint import pprint
+from typing import Any
+
+from pydantic import BaseModel
+
+from mlb_statsapi import __version__
+from mlb_statsapi.client.sync_client import MlbClient
+from mlb_statsapi.endpoints.registry import ENDPOINTS
+from mlb_statsapi.exceptions import MlbApiError, MlbValidationError
+
+DEFAULTS: dict[str, dict[str, str]] = {
+    "schedule": {"sportId": "1"},
+    "teams": {"sportId": "1"},
+    "standings": {"leagueId": "103,104"},
+    "stats_leaders": {"sportId": "1", "leaderCategories": "homeRuns"},
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="mlb-statsapi",
+        description="Query MLB Stats API endpoints and display results.",
+    )
+    parser.add_argument(
+        "endpoint",
+        nargs="?",
+        help="endpoint name (e.g. schedule, game_boxscore)",
+    )
+    parser.add_argument(
+        "params",
+        nargs="*",
+        metavar="KEY=VALUE",
+        help="endpoint parameters as KEY=VALUE pairs",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        choices=["json", "py"],
+        default="json",
+        help="output format (default: json)",
+    )
+    parser.add_argument(
+        "-l",
+        "--list-endpoints",
+        action="store_true",
+        help="list all available endpoints",
+    )
+    parser.add_argument(
+        "-H",
+        "--help-endpoint",
+        action="store_true",
+        help="show detailed info for the given endpoint",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
+    return parser
+
+
+def parse_params(raw: list[str]) -> dict[str, str]:
+    """Parse KEY=VALUE pairs into a dict."""
+    params: dict[str, str] = {}
+    for item in raw:
+        if "=" not in item:
+            raise ValueError(f"Invalid parameter '{item}'. Expected KEY=VALUE format.")
+        key, value = item.split("=", 1)
+        params[key] = value
+    return params
+
+
+def list_endpoints() -> None:
+    """Print all endpoint names grouped by category."""
+    groups: dict[str, list[str]] = {}
+    for name in sorted(ENDPOINTS):
+        prefix = name.split("_")[0] if "_" in name else name
+        groups.setdefault(prefix, []).append(name)
+
+    print(f"Available endpoints ({len(ENDPOINTS)} total):\n")
+    for prefix, names in sorted(groups.items()):
+        print(f"  {prefix + ':':20s} {', '.join(names)}")
+
+
+def help_endpoint(name: str) -> None:
+    """Print detailed info for a single endpoint."""
+    name = name.replace("-", "_")
+    ep = ENDPOINTS.get(name)
+    if ep is None:
+        print(f"Unknown endpoint: {name}", file=sys.stderr)
+        print("Use --list-endpoints to see available endpoints.", file=sys.stderr)
+        return
+
+    print(f"Endpoint: {name}")
+    print(f"  URL:             {ep.url_template}")
+    print(f"  Version:         {ep.default_version}")
+
+    if ep.path_params:
+        path_str = ", ".join(
+            f"{k}={v!r}" if v else k for k, v in ep.path_params.items()
+        )
+        print(f"  Path params:     {path_str}")
+
+    if ep.query_params:
+        print(f"  Query params:    {', '.join(ep.query_params)}")
+
+    if ep.required_params and any(ep.required_params):
+        groups = " OR ".join("(" + ", ".join(g) + ")" for g in ep.required_params if g)
+        print(f"  Required:        {groups}")
+
+    defaults = DEFAULTS.get(name)
+    if defaults:
+        default_str = ", ".join(f"{k}={v}" for k, v in defaults.items())
+        print(f"  Defaults:        {default_str}")
+
+    if ep.response_model:
+        print(f"  Response model:  {ep.response_model.__name__}")
+
+    if ep.note:
+        print(f"  Note:            {ep.note}")
+
+
+def format_output(result: BaseModel, mode: str) -> None:
+    """Print result in the chosen format."""
+    if mode == "json":
+        print(result.model_dump_json(indent=2, by_alias=True))
+    else:
+        try:
+            from rich.pretty import pprint as rich_pprint
+
+            rich_pprint(result)
+        except ImportError:
+            pprint(result.model_dump())
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point. Returns exit code."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.list_endpoints:
+        list_endpoints()
+        return 0
+
+    if not args.endpoint:
+        parser.print_help()
+        return 1
+
+    endpoint = args.endpoint.replace("-", "_")
+
+    if args.help_endpoint:
+        help_endpoint(endpoint)
+        return 0
+
+    try:
+        params = parse_params(args.params)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    # Apply sensible defaults (user params override)
+    merged: dict[str, Any] = {**DEFAULTS.get(endpoint, {}), **params}
+
+    try:
+        with MlbClient() as client:
+            result = client.get(endpoint, **merged)
+    except MlbApiError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except MlbValidationError as e:
+        print(f"Validation error: {e}", file=sys.stderr)
+        if e.raw_data:
+            print(json.dumps(e.raw_data, indent=2))
+        return 1
+
+    format_output(result, args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,224 @@
+"""Tests for the mlb-statsapi CLI."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import respx
+
+from mlb_statsapi.cli import (
+    DEFAULTS,
+    build_parser,
+    help_endpoint,
+    list_endpoints,
+    main,
+    parse_params,
+)
+from tests.conftest import load_fixture
+
+# ---------------------------------------------------------------------------
+# Unit tests (no network / mocking)
+# ---------------------------------------------------------------------------
+
+
+class TestParseParams:
+    """Test KEY=VALUE parsing."""
+
+    def test_valid_pairs(self):
+        assert parse_params(["sportId=1", "date=07/01/2024"]) == {
+            "sportId": "1",
+            "date": "07/01/2024",
+        }
+
+    def test_value_with_equals(self):
+        assert parse_params(["foo=a=b"]) == {"foo": "a=b"}
+
+    def test_empty_list(self):
+        assert parse_params([]) == {}
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Invalid parameter"):
+            parse_params(["badparam"])
+
+
+class TestBuildParser:
+    """Test argparse configuration."""
+
+    def test_endpoint_and_params(self):
+        parser = build_parser()
+        args = parser.parse_args(["schedule", "sportId=1", "date=07/01/2024"])
+        assert args.endpoint == "schedule"
+        assert args.params == ["sportId=1", "date=07/01/2024"]
+        assert args.output == "json"
+
+    def test_output_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["schedule", "-o", "py"])
+        assert args.output == "py"
+
+    def test_list_endpoints_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["--list-endpoints"])
+        assert args.list_endpoints is True
+
+    def test_help_endpoint_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["schedule", "--help-endpoint"])
+        assert args.help_endpoint is True
+
+
+class TestListEndpoints:
+    """Test endpoint listing."""
+
+    def test_output_contains_endpoints(self, capsys):
+        list_endpoints()
+        out = capsys.readouterr().out
+        assert "schedule" in out
+        assert "teams" in out
+        assert "game" in out
+        assert "Available endpoints" in out
+
+
+class TestHelpEndpoint:
+    """Test endpoint help display."""
+
+    def test_known_endpoint(self, capsys):
+        help_endpoint("schedule")
+        out = capsys.readouterr().out
+        assert "Endpoint: schedule" in out
+        assert "sportId" in out
+
+    def test_hyphen_normalization(self, capsys):
+        help_endpoint("game-boxscore")
+        out = capsys.readouterr().out
+        assert "Endpoint: game_boxscore" in out
+
+    def test_unknown_endpoint(self, capsys):
+        help_endpoint("bogus")
+        err = capsys.readouterr().err
+        assert "Unknown endpoint" in err
+
+    def test_shows_defaults(self, capsys):
+        help_endpoint("standings")
+        out = capsys.readouterr().out
+        assert "Defaults:" in out
+        assert "103,104" in out
+
+
+class TestDefaults:
+    """Test that sensible defaults are applied."""
+
+    def test_defaults_applied(self):
+        merged = {**DEFAULTS.get("schedule", {}), **{}}
+        assert merged["sportId"] == "1"
+
+    def test_user_overrides_defaults(self):
+        merged = {**DEFAULTS.get("schedule", {}), **{"sportId": "11"}}
+        assert merged["sportId"] == "11"
+
+
+class TestHyphenNormalization:
+    """Test endpoint name normalization."""
+
+    def test_hyphen_to_underscore(self):
+        assert "game-boxscore".replace("-", "_") == "game_boxscore"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (with respx mocking + capsys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_api():
+    with respx.mock(base_url="https://statsapi.mlb.com/api") as api:
+        yield api
+
+
+class TestMainIntegration:
+    """Test the main() entry point end-to-end."""
+
+    def test_list_endpoints_exit_0(self, capsys):
+        rc = main(["--list-endpoints"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "schedule" in out
+
+    def test_no_endpoint_prints_help(self, capsys):
+        rc = main([])
+        assert rc == 1
+
+    def test_help_endpoint_exit_0(self, capsys):
+        rc = main(["schedule", "--help-endpoint"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Endpoint: schedule" in out
+
+    def test_bogus_endpoint_exit_1(self, capsys):
+        rc = main(["bogus_endpoint"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+    def test_invalid_param_format_exit_1(self, capsys):
+        rc = main(["schedule", "badparam"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Invalid parameter" in err
+
+    def test_schedule_json_output(self, mock_api, capsys):
+        data = load_fixture("schedule")
+        mock_api.get("/v1/schedule").respond(200, json=data)
+
+        rc = main(["schedule", "sportId=1", "date=07/01/2024"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert "dates" in parsed
+
+    def test_schedule_py_output(self, mock_api, capsys):
+        data = load_fixture("schedule")
+        mock_api.get("/v1/schedule").respond(200, json=data)
+
+        rc = main(["schedule", "sportId=1", "-o", "py"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # py mode output is not JSON
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(out)
+
+    def test_sports_with_defaults(self, mock_api, capsys):
+        data = load_fixture("sports")
+        mock_api.get("/v1/sports").respond(200, json=data)
+
+        rc = main(["sports"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert "sports" in parsed
+
+    def test_http_error_exit_1(self, mock_api, capsys):
+        mock_api.get("/v1/sports").respond(500)
+
+        rc = main(["sports"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+    def test_hyphen_endpoint_name(self, mock_api, capsys):
+        data = load_fixture("boxscore")
+        mock_api.get("/v1/game/744914/boxscore").respond(200, json=data)
+
+        rc = main(["game-boxscore", "gamePk=744914"])
+        assert rc == 0
+
+    def test_standings_uses_defaults(self, mock_api, capsys):
+        data = load_fixture("standings")
+        mock_api.get("/v1/standings").respond(200, json=data)
+
+        rc = main(["standings"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert "records" in parsed


### PR DESCRIPTION
## Summary
- Adds `mlb-statsapi` CLI command to query any endpoint with `KEY=VALUE` params and `json`/`py` output modes (closes #26)
- Includes `--list-endpoints` for discovery and `--help-endpoint` for per-endpoint details
- Sensible defaults for common endpoints (schedule, teams, standings, stats_leaders)
- `rich` as optional dep via `pip install mlb-statsapi-pydantic[cli]`, falls back to `pprint`
- 27 tests (unit + integration with respx mocking)

## Test plan
- [x] `python -m pytest tests/test_cli.py` — 27 tests passing
- [x] `python -m mypy src/mlb_statsapi/cli.py src/mlb_statsapi/__main__.py` — clean
- [x] Full test suite — 288 tests passing
- [ ] Manual smoke test: `pip install -e .` then `mlb-statsapi schedule date=07/01/2024`
- [ ] Manual smoke test: `mlb-statsapi --list-endpoints`
- [ ] Manual smoke test: `mlb-statsapi schedule --help-endpoint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)