### PR TITLE
feat: add live game client with WebSocket push notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,37 @@ asyncio.run(main())
 
 See `examples/` for more details
 
+### Live Game
+
+Watch games in real time with WebSocket push notifications:
+
+```python
+import asyncio
+from mlb_statsapi import LiveGameClient, GameEvent, GameEventData
+
+async def main():
+    client = LiveGameClient(game_pk=824782)
+
+    @client.on(GameEvent.PITCH)
+    async def on_pitch(event: GameEventData):
+        pe = event.play_event
+        if pe and pe.details:
+            print(f"Pitch: {pe.details.description}")
+
+    await client.watch()
+
+asyncio.run(main())
+```
+
+See [docs/live-game-client.md](docs/live-game-client.md) for full documentation on granularity, event types, sync client, and more.
+
 ## Features
 
 - Fully-typed Pydantic v2 models for all major endpoints
 - Sync (`MlbClient`) and async (`AsyncMlbClient`) HTTP clients
+- **Live game client** with WebSocket push notifications and REST enrichment
+- Configurable granularity (every pitch, every play, scoring only, custom)
+- Both async (`LiveGameClient`) and sync (`SyncLiveGameClient`) live clients
 - Enum helpers for game types and team IDs
 - Endpoint registry with URL building and parameter validation
 - `extra="allow"` on all models — new API fields won't break your code

--- a/docs/live-game-client.md
+++ b/docs/live-game-client.md
@@ -1,0 +1,308 @@
+# Live Game Client
+
+Watch MLB games in real time using WebSocket push notifications with optional REST enrichment.
+
+The live game client connects to MLB's gameday WebSocket at
+`wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/<gamePk>`
+to receive lightweight notifications, then fetches full game data via REST
+based on your configured granularity.
+
+## Installation
+
+The live client requires the `httpx-ws` package, which is included as a dependency:
+
+```bash
+pip install mlb-statsapi-pydantic
+```
+
+## Quick Start
+
+```python
+import asyncio
+from mlb_statsapi import LiveGameClient, GameEvent, GameEventData
+
+async def main():
+    client = LiveGameClient(game_pk=824782)
+
+    @client.on(GameEvent.PITCH)
+    async def on_pitch(event: GameEventData):
+        pe = event.play_event
+        if pe and pe.details:
+            print(f"Pitch: {pe.details.description}")
+
+    @client.on(GameEvent.RUN)
+    async def on_run(event: GameEventData):
+        ls = event.feed.live_data.linescore
+        print(f"Score: {ls.teams.away.runs}-{ls.teams.home.runs}")
+
+    await client.watch()
+
+asyncio.run(main())
+```
+
+## Architecture
+
+```
+WebSocket ──push──> WsMessage ──filter──> REST fetch ──> Event detection ──> Callbacks
+                                  |                       (LiveFeedResponse)
+                                  no
+                                  |
+                                  v
+                             Skip update
+```
+
+1. **WebSocket** receives `WsMessage` notifications (~every 10-30s during play)
+2. **Granularity filter** checks if `gameEvents`/`logicalEvents` match your configured triggers
+3. **REST enrichment** fetches the full `LiveFeedResponse` (or `game_diff`)
+4. **Event detection** compares old vs new feed state to classify what happened
+5. **Dispatch** fires registered callbacks and pushes to stream queues
+
+## Clients
+
+### AsyncMlbClient (Async)
+
+```python
+from mlb_statsapi import LiveGameClient, LiveGameConfig
+
+async with LiveGameClient(game_pk=824782) as client:
+    @client.on(GameEvent.PITCH)
+    async def on_pitch(event: GameEventData):
+        ...
+
+    await client.watch()
+```
+
+### SyncLiveGameClient (Sync)
+
+Runs the async client in a background thread. Callbacks are plain functions:
+
+```python
+from mlb_statsapi import SyncLiveGameClient, GameEvent, GameEventData
+
+with SyncLiveGameClient(game_pk=824782) as client:
+    @client.on(GameEvent.PITCH)
+    def on_pitch(event: GameEventData):
+        print(f"Pitch: {event.play_event.details.description}")
+
+    client.watch()  # blocks until game ends
+```
+
+## Event Types
+
+Events are detected by comparing consecutive `LiveFeedResponse` states after REST enrichment:
+
+| Event | Trigger |
+|---|---|
+| `WS_MESSAGE` | Every raw WebSocket notification (no REST fetch needed) |
+| `UPDATE` | Any change to the live feed |
+| `GAME_START` | `AbstractGameState` transitions to `Live` |
+| `GAME_END` | `AbstractGameState` transitions to `Final` |
+| `GAME_STATE_CHANGE` | Any `AbstractGameState` transition |
+| `PITCH` | New pitch event in current play's `play_events` |
+| `HIT` | Pitch with `details.is_in_play == True` |
+| `PLAY_COMPLETE` | New completed play in `all_plays` |
+| `STRIKEOUT` | Completed play with strikeout event type |
+| `WALK` | Completed play with walk/intentional walk |
+| `HOME_RUN` | Completed play with home run event type |
+| `RUN` | Score change detected in linescore |
+| `INNING_CHANGE` | `current_inning` or `inning_half` changes |
+| `SUBSTITUTION` | Play event with `is_substitution == True` |
+
+## Registering Callbacks
+
+### Decorator
+
+```python
+@client.on(GameEvent.PITCH)
+async def on_pitch(event: GameEventData):
+    ...
+```
+
+### Direct registration
+
+```python
+async def my_handler(event: GameEventData):
+    ...
+
+client.on(GameEvent.PITCH, handler=my_handler)
+```
+
+### Multiple events
+
+```python
+@client.on([GameEvent.STRIKEOUT, GameEvent.WALK, GameEvent.HOME_RUN])
+async def on_at_bat_result(event: GameEventData):
+    print(f"{event.event_type}: {event.play.result.description}")
+```
+
+## Async Iterator (Stream)
+
+Use `stream()` as an alternative to callbacks:
+
+```python
+async with LiveGameClient(game_pk=824782) as client:
+    # Start watch in the background
+    watch_task = asyncio.create_task(client.watch())
+
+    async for event in client.stream(GameEvent.PITCH, GameEvent.RUN):
+        print(event.event_type)
+
+    await watch_task
+```
+
+Pass no arguments to receive all events:
+
+```python
+async for event in client.stream():
+    ...
+```
+
+## Granularity
+
+Controls which WebSocket notifications trigger a REST fetch. Lower granularity = fewer REST calls = less bandwidth.
+
+| Preset | Triggers on |
+|---|---|
+| `EVERY_UPDATE` | Every WebSocket message |
+| `EVERY_PITCH` | Pitch results, play outcomes (default) |
+| `EVERY_PLAY` | Play completions, substitutions |
+| `SCORING_ONLY` | `hit_into_play_score` events |
+| `CUSTOM` | User-provided list of trigger values |
+
+```python
+from mlb_statsapi import LiveGameConfig, FetchGranularity
+
+# Only fetch on scoring plays
+config = LiveGameConfig(granularity=FetchGranularity.SCORING_ONLY)
+client = LiveGameClient(game_pk=824782, config=config)
+```
+
+### Custom triggers
+
+```python
+config = LiveGameConfig(
+    granularity=FetchGranularity.CUSTOM,
+    custom_triggers=["caught_stealing_2b", "runnersInScoringPosition"],
+)
+```
+
+Custom triggers match against both `gameEvents` and `logicalEvents` from the WebSocket message.
+
+## Configuration
+
+`LiveGameConfig` controls all client behavior:
+
+```python
+config = LiveGameConfig(
+    # Granularity
+    granularity=FetchGranularity.EVERY_PITCH,
+    custom_triggers=[],           # for CUSTOM granularity
+
+    # Enrichment
+    fetch_diff=False,             # also fetch game_diff between timecodes
+
+    # REST fallback (when WebSocket unavailable)
+    poll_interval=10.0,           # seconds between REST polls
+    pregame_poll_interval=60.0,   # seconds between polls in Preview state
+    use_rest_fallback=True,       # fall back to REST if WS fails
+
+    # WebSocket
+    ws_reconnect_delay=2.0,       # initial reconnect delay (seconds)
+    ws_max_reconnect_delay=60.0,  # max reconnect delay after backoff
+
+    # Lifecycle
+    postgame_linger=0.0,          # seconds to stay connected after game ends
+    max_retries=5,                # max retries for initial REST fetch
+    retry_delay=5.0,              # seconds between retries
+)
+```
+
+## GameEventData
+
+Every callback receives a `GameEventData` object:
+
+| Field | Type | Description |
+|---|---|---|
+| `event_type` | `GameEvent` | Which event triggered this callback |
+| `game_pk` | `int` | Game primary key |
+| `feed` | `LiveFeedResponse` | Current full game state |
+| `previous_feed` | `LiveFeedResponse` | Previous game state |
+| `ws_message` | `WsMessage` | Raw WebSocket notification that triggered the fetch |
+| `play` | `Play` | The relevant play (for play-related events) |
+| `play_event` | `PlayEvent` | The relevant pitch/action (for pitch-related events) |
+| `start_timecode` | `str` | Timecode of previous update |
+| `end_timecode` | `str` | Timecode of current update |
+| `diff` | `LiveFeedResponse` | Diff feed (when `fetch_diff=True`) |
+
+## REST API Access
+
+The underlying REST client is available for ad-hoc queries:
+
+```python
+async with LiveGameClient(game_pk=824782) as client:
+    # Use client.api for any REST call
+    boxscore = await client.api.game_boxscore(824782)
+
+    @client.on(GameEvent.HOME_RUN)
+    async def on_hr(event: GameEventData):
+        # Fetch additional data on demand
+        batter_id = event.play.matchup.batter.id
+        person = await client.api.person(batter_id)
+        print(f"Home run by {person.people[0].full_name}!")
+
+    await client.watch()
+```
+
+## WebSocket Message Model
+
+The raw WebSocket notifications are parsed into `WsMessage`:
+
+```python
+from mlb_statsapi.models import WsMessage
+
+# Fields available on every WS notification:
+msg.time_stamp       # "20260404_201235"
+msg.game_pk          # "824782"
+msg.update_id        # UUID string
+msg.wait             # server-suggested poll interval (seconds)
+msg.game_events      # ["called_strike"]
+msg.logical_events   # ["countChange", "count01", "basesEmpty"]
+msg.change_event     # ChangeEvent(type="new_entry")
+msg.is_delay         # True/False/None
+```
+
+### Known gameEvents values
+
+Pitch results: `ball`, `called_strike`, `swinging_strike`, `foul`, `foul_tip`, `foul_bunt`, `blocked_ball`, `hit_into_play`, `hit_into_play_no_out`, `hit_into_play_score`
+
+Play outcomes: `single`, `double`, `triple`, `field_out`, `strikeout`, `walk`, `force_out`, `sac_fly`, `grounded_into_double_play`, `caught_stealing_2b`
+
+Other: `at_bat_start`, `pitching_substitution`, `offensive_substitution`, `defensive_switch`, `batter_timeout`, `mound_visit`, `game_advisory`
+
+### Known logicalEvents values
+
+Count: `countChange`, `count00` through `count42`
+
+Batter: `newBatter`, `newRightHandedHit`, `newLeftHandedHit`, `batterSwitchedToLeftHanded`, `batterSwitchedToRightHanded`
+
+Baserunners: `basesEmpty`, `runnerOnFirst`, `runnerOnSecond`, `runnerOnThird`, `runnersOnFirstAndSecond`, `runnersOnFirstAndThird`, `runnersOnSecondAndThird`, `runnersInScoringPosition`, `basesLoaded`
+
+Inning: `newHalfInning`, `midInning`
+
+Pitcher: `pitcherChange`, `pitcherChangeComplete`
+
+Defense: `defensiveSubstitution`
+
+### changeEvent types
+
+- `new_entry` -- new play event added
+- `full_refresh` -- full game state refresh
+- `correction` -- correction to previous data (may include `changed_at_bat_indexes`)
+
+## Error Handling
+
+- **WebSocket disconnect**: Auto-reconnects with exponential backoff (2s to 60s)
+- **WebSocket unavailable**: Falls back to REST polling when `use_rest_fallback=True`
+- **REST errors**: Retries with backoff up to `max_retries`
+- **Callback errors**: Logged but do not crash the client
+- **Unknown WS message format**: Logged and skipped

--- a/examples/live_game.py
+++ b/examples/live_game.py
@@ -1,0 +1,149 @@
+"""Watch a live MLB game using the LiveGameClient.
+
+Demonstrates async callback registration, granularity configuration,
+and the sync client wrapper.
+
+Usage:
+    python examples/live_game.py 824782
+    python examples/live_game.py 824782 --scoring-only
+    python examples/live_game.py --today
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import sys
+from datetime import date
+
+from mlb_statsapi import (
+    FetchGranularity,
+    GameEvent,
+    GameEventData,
+    LiveGameClient,
+    LiveGameConfig,
+    MlbClient,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+    stream=sys.stderr,
+)
+
+
+async def watch_game(game_pk: int, granularity: FetchGranularity) -> None:
+    """Watch a game and print events as they happen."""
+    config = LiveGameConfig(granularity=granularity)
+
+    async with LiveGameClient(game_pk=game_pk, config=config) as client:
+
+        @client.on(GameEvent.GAME_START)
+        async def on_start(event: GameEventData) -> None:
+            gd = event.feed.game_data if event.feed else None
+            if gd and gd.teams and gd.teams.away and gd.teams.home:
+                away = gd.teams.away.name
+                home = gd.teams.home.name
+                print(f"\n{'=' * 50}")
+                print(f"  Game started: {away} @ {home}")
+                print(f"{'=' * 50}\n")
+
+        @client.on(GameEvent.PITCH)
+        async def on_pitch(event: GameEventData) -> None:
+            pe = event.play_event
+            if pe and pe.details:
+                desc = pe.details.description or "Pitch"
+                count = pe.count
+                count_str = f" ({count.balls}-{count.strikes})" if count else ""
+                print(f"  {desc}{count_str}")
+
+        @client.on(GameEvent.PLAY_COMPLETE)
+        async def on_play(event: GameEventData) -> None:
+            play = event.play
+            if play and play.result:
+                desc = play.result.description or play.result.event
+                print(f"  >> {desc}")
+
+        @client.on(GameEvent.RUN)
+        async def on_run(event: GameEventData) -> None:
+            ls = (
+                event.feed.live_data.linescore
+                if event.feed and event.feed.live_data
+                else None
+            )
+            if ls and ls.teams:
+                away = ls.teams.away.runs or 0
+                home = ls.teams.home.runs or 0
+                print(f"  *** Score: {away} - {home} ***")
+
+        @client.on(GameEvent.INNING_CHANGE)
+        async def on_inning(event: GameEventData) -> None:
+            ls = (
+                event.feed.live_data.linescore
+                if event.feed and event.feed.live_data
+                else None
+            )
+            if ls:
+                half = ls.inning_half or "Top"
+                inning = ls.current_inning or "?"
+                print(f"\n--- {half} {inning} ---")
+
+        @client.on(GameEvent.GAME_END)
+        async def on_end(event: GameEventData) -> None:
+            ls = (
+                event.feed.live_data.linescore
+                if event.feed and event.feed.live_data
+                else None
+            )
+            if ls and ls.teams:
+                away = ls.teams.away.runs or 0
+                home = ls.teams.home.runs or 0
+                print(f"\n{'=' * 50}")
+                print(f"  Final: {away} - {home}")
+                print(f"{'=' * 50}")
+
+        print(f"Watching game {game_pk} ({granularity}) ...")
+        await client.watch()
+
+
+def show_todays_games() -> None:
+    """List today's games with game PKs."""
+    today = date.today().strftime("%m/%d/%Y")
+    with MlbClient() as client:
+        schedule = client.schedule(date=today)
+
+    if not schedule.dates:
+        print("No games scheduled today.", file=sys.stderr)
+        return
+
+    print(f"Games for {schedule.dates[0].date}:\n", file=sys.stderr)
+    for game in schedule.dates[0].games:
+        status = game.status.detailed_state if game.status else "?"
+        away = game.teams.away.team.name
+        home = game.teams.home.team.name
+        print(f"  {game.game_pk}  {away} @ {home}  [{status}]", file=sys.stderr)
+
+    print("\nUsage: python examples/live_game.py <game_pk>", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Watch a live MLB game")
+    parser.add_argument("game_pk", nargs="?", type=int, help="Game primary key")
+    parser.add_argument("--today", action="store_true", help="Show today's games")
+    parser.add_argument(
+        "--scoring-only",
+        action="store_true",
+        help="Only fetch on scoring events (less bandwidth)",
+    )
+    args = parser.parse_args()
+
+    if args.today or args.game_pk is None:
+        show_todays_games()
+    else:
+        gran = (
+            FetchGranularity.SCORING_ONLY
+            if args.scoring_only
+            else FetchGranularity.EVERY_PITCH
+        )
+        asyncio.run(watch_game(args.game_pk, gran))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Typing :: Typed",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["pydantic>=2.0", "httpx>=0.25"]
+dependencies = ["pydantic>=2.0", "httpx>=0.25", "httpx-ws>=0.6"]
 
 [project.urls]
 Homepage = "https://github.com/DarkSideOfTheMat/mlb-statsapi-pydantic"

--- a/src/mlb_statsapi/__init__.py
+++ b/src/mlb_statsapi/__init__.py
@@ -3,6 +3,14 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from mlb_statsapi.client.async_client import AsyncMlbClient
+from mlb_statsapi.client.live import (
+    FetchGranularity,
+    GameEvent,
+    GameEventData,
+    LiveGameClient,
+    LiveGameConfig,
+    SyncLiveGameClient,
+)
 from mlb_statsapi.client.sync_client import MlbClient
 from mlb_statsapi.exceptions import MlbApiError, MlbValidationError
 
@@ -13,8 +21,14 @@ except PackageNotFoundError:
 
 __all__ = [
     "AsyncMlbClient",
+    "FetchGranularity",
+    "GameEvent",
+    "GameEventData",
+    "LiveGameClient",
+    "LiveGameConfig",
     "MlbApiError",
     "MlbClient",
     "MlbValidationError",
+    "SyncLiveGameClient",
     "__version__",
 ]

--- a/src/mlb_statsapi/client/live.py
+++ b/src/mlb_statsapi/client/live.py
@@ -233,20 +233,20 @@ def _should_fetch(msg: WsMessage, config: LiveGameConfig) -> bool:
 # Event detection
 # ---------------------------------------------------------------------------
 
-# Event types that indicate a strikeout — use .value for Python 3.10 compat
+# Event types that indicate a strikeout
 _STRIKEOUT_EVENTS: frozenset[str] = frozenset(
     {
-        EventType.STRIKEOUT.value,
-        EventType.STRIKE_OUT.value,
-        EventType.STRIKEOUT_DOUBLE_PLAY.value,
-        EventType.STRIKEOUT_TRIPLE_PLAY.value,
+        EventType.STRIKEOUT,
+        EventType.STRIKE_OUT,
+        EventType.STRIKEOUT_DOUBLE_PLAY,
+        EventType.STRIKEOUT_TRIPLE_PLAY,
     }
 )
 
 _WALK_EVENTS: frozenset[str] = frozenset(
     {
-        EventType.WALK.value,
-        EventType.INTENT_WALK.value,
+        EventType.WALK,
+        EventType.INTENT_WALK,
     }
 )
 
@@ -300,9 +300,9 @@ def _detect_events(
 
     if old_state and new_state and old_state != new_state:
         events.append(_make(GameEvent.GAME_STATE_CHANGE))
-        if new_state == AbstractGameState.LIVE.value:
+        if new_state == AbstractGameState.LIVE:
             events.append(_make(GameEvent.GAME_START))
-        elif new_state == AbstractGameState.FINAL.value:
+        elif new_state == AbstractGameState.FINAL:
             events.append(_make(GameEvent.GAME_END))
 
     new_plays = new.live_data.plays if new.live_data else None
@@ -317,12 +317,11 @@ def _detect_events(
 
         event_type = play.result.event_type if play.result else None
         if event_type:
-            et = event_type if isinstance(event_type, str) else event_type.value
-            if et in _STRIKEOUT_EVENTS:
+            if event_type in _STRIKEOUT_EVENTS:
                 events.append(_make(GameEvent.STRIKEOUT, play=play))
-            elif et in _WALK_EVENTS:
+            elif event_type in _WALK_EVENTS:
                 events.append(_make(GameEvent.WALK, play=play))
-            elif et == EventType.HOME_RUN.value:
+            elif event_type == EventType.HOME_RUN:
                 events.append(_make(GameEvent.HOME_RUN, play=play))
 
     # --- New pitches in current play ---
@@ -452,9 +451,9 @@ async def _rest_poll(
         interval = config.poll_interval
         if last_feed and last_feed.game_data and last_feed.game_data.status:
             state = last_feed.game_data.status.abstract_game_state or ""
-            if state == AbstractGameState.PREVIEW.value:
+            if state == AbstractGameState.PREVIEW:
                 interval = config.pregame_poll_interval
-            elif state == AbstractGameState.FINAL.value:
+            elif state == AbstractGameState.FINAL:
                 return
 
         try:
@@ -863,7 +862,7 @@ class LiveGameClient:
     def _is_game_over(feed: LiveFeedResponse) -> bool:
         if feed.game_data and feed.game_data.status:
             state = feed.game_data.status.abstract_game_state
-            return state == AbstractGameState.FINAL.value if state else False
+            return state == AbstractGameState.FINAL if state else False
         return False
 
 

--- a/src/mlb_statsapi/client/live.py
+++ b/src/mlb_statsapi/client/live.py
@@ -233,20 +233,20 @@ def _should_fetch(msg: WsMessage, config: LiveGameConfig) -> bool:
 # Event detection
 # ---------------------------------------------------------------------------
 
-# Event types that indicate a strikeout
+# Event types that indicate a strikeout — use .value for Python 3.10 compat
 _STRIKEOUT_EVENTS: frozenset[str] = frozenset(
     {
-        EventType.STRIKEOUT,
-        EventType.STRIKE_OUT,
-        EventType.STRIKEOUT_DOUBLE_PLAY,
-        EventType.STRIKEOUT_TRIPLE_PLAY,
+        EventType.STRIKEOUT.value,
+        EventType.STRIKE_OUT.value,
+        EventType.STRIKEOUT_DOUBLE_PLAY.value,
+        EventType.STRIKEOUT_TRIPLE_PLAY.value,
     }
 )
 
 _WALK_EVENTS: frozenset[str] = frozenset(
     {
-        EventType.WALK,
-        EventType.INTENT_WALK,
+        EventType.WALK.value,
+        EventType.INTENT_WALK.value,
     }
 )
 
@@ -300,9 +300,9 @@ def _detect_events(
 
     if old_state and new_state and old_state != new_state:
         events.append(_make(GameEvent.GAME_STATE_CHANGE))
-        if str(new_state) == str(AbstractGameState.LIVE):
+        if new_state == AbstractGameState.LIVE.value:
             events.append(_make(GameEvent.GAME_START))
-        elif str(new_state) == str(AbstractGameState.FINAL):
+        elif new_state == AbstractGameState.FINAL.value:
             events.append(_make(GameEvent.GAME_END))
 
     new_plays = new.live_data.plays if new.live_data else None
@@ -317,12 +317,12 @@ def _detect_events(
 
         event_type = play.result.event_type if play.result else None
         if event_type:
-            et = str(event_type)
+            et = event_type if isinstance(event_type, str) else event_type.value
             if et in _STRIKEOUT_EVENTS:
                 events.append(_make(GameEvent.STRIKEOUT, play=play))
             elif et in _WALK_EVENTS:
                 events.append(_make(GameEvent.WALK, play=play))
-            elif et == str(EventType.HOME_RUN):
+            elif et == EventType.HOME_RUN.value:
                 events.append(_make(GameEvent.HOME_RUN, play=play))
 
     # --- New pitches in current play ---
@@ -451,10 +451,10 @@ async def _rest_poll(
         # Determine poll interval based on game state
         interval = config.poll_interval
         if last_feed and last_feed.game_data and last_feed.game_data.status:
-            state = str(last_feed.game_data.status.abstract_game_state or "")
-            if state == str(AbstractGameState.PREVIEW):
+            state = last_feed.game_data.status.abstract_game_state or ""
+            if state == AbstractGameState.PREVIEW.value:
                 interval = config.pregame_poll_interval
-            elif state == str(AbstractGameState.FINAL):
+            elif state == AbstractGameState.FINAL.value:
                 return
 
         try:
@@ -863,7 +863,7 @@ class LiveGameClient:
     def _is_game_over(feed: LiveFeedResponse) -> bool:
         if feed.game_data and feed.game_data.status:
             state = feed.game_data.status.abstract_game_state
-            return str(state) == str(AbstractGameState.FINAL) if state else False
+            return state == AbstractGameState.FINAL.value if state else False
         return False
 
 

--- a/src/mlb_statsapi/client/live.py
+++ b/src/mlb_statsapi/client/live.py
@@ -1,0 +1,988 @@
+"""Live game client with WebSocket push notifications and REST enrichment.
+
+Provides :class:`LiveGameClient` (async) and :class:`SyncLiveGameClient`
+(sync) for watching MLB games in real time. The client connects to the
+undocumented MLB gameday WebSocket at
+``wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/<gamePk>``
+to receive lightweight push notifications, then optionally fetches full
+game data via REST based on user-configured granularity.
+
+Usage (async)::
+
+    async with LiveGameClient(game_pk=824782) as client:
+
+        @client.on(GameEvent.PITCH)
+        async def on_pitch(event: GameEventData):
+            pe = event.play_event
+            if pe and pe.details:
+                print(f"Pitch: {pe.details.description}")
+
+        await client.watch()
+
+Usage (sync)::
+
+    with SyncLiveGameClient(game_pk=824782) as client:
+
+        @client.on(GameEvent.PITCH)
+        def on_pitch(event: GameEventData):
+            pe = event.play_event
+            if pe and pe.details:
+                print(f"Pitch: {pe.details.description}")
+
+        client.watch()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import threading
+from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from typing import Any
+
+import httpx
+
+from mlb_statsapi.client.async_client import AsyncMlbClient
+from mlb_statsapi.exceptions import MlbApiError
+from mlb_statsapi.models._base import MlbBaseModel
+from mlb_statsapi.models.enums import AbstractGameState, EventType
+from mlb_statsapi.models.livefeed import LiveFeedResponse, Play, PlayEvent
+from mlb_statsapi.models.ws import WsGameEvent, WsMessage
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of StrEnum for Python < 3.11."""
+
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Enums and configuration
+# ---------------------------------------------------------------------------
+
+
+class GameEvent(StrEnum):
+    """Client-side events detected after comparing game states.
+
+    These events are emitted by :class:`LiveGameClient` when changes
+    are detected in the live feed data.
+    """
+
+    WS_MESSAGE = "ws_message"
+    UPDATE = "update"
+    GAME_START = "game_start"
+    GAME_END = "game_end"
+    GAME_STATE_CHANGE = "game_state_change"
+    PITCH = "pitch"
+    HIT = "hit"
+    PLAY_COMPLETE = "play_complete"
+    STRIKEOUT = "strikeout"
+    WALK = "walk"
+    HOME_RUN = "home_run"
+    RUN = "run"
+    INNING_CHANGE = "inning_change"
+    SUBSTITUTION = "substitution"
+
+
+class FetchGranularity(StrEnum):
+    """Preset granularity levels controlling when WS notifications trigger
+    a REST fetch for full game data.
+    """
+
+    EVERY_UPDATE = "every_update"
+    EVERY_PITCH = "every_pitch"
+    EVERY_PLAY = "every_play"
+    SCORING_ONLY = "scoring_only"
+    CUSTOM = "custom"
+
+
+class LiveGameConfig(MlbBaseModel):
+    """Configuration for :class:`LiveGameClient`."""
+
+    # WebSocket
+    ws_url_template: str = (
+        "wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/{game_pk}"
+    )
+    ws_reconnect_delay: float = 2.0
+    ws_max_reconnect_delay: float = 60.0
+
+    # Granularity — controls when WS notifications trigger REST fetches
+    granularity: FetchGranularity | str = FetchGranularity.EVERY_PITCH
+    custom_triggers: list[str] = []
+
+    # Enrichment
+    fetch_diff: bool = False
+
+    # REST polling fallback
+    poll_interval: float = 10.0
+    pregame_poll_interval: float = 60.0
+    use_rest_fallback: bool = True
+
+    # Lifecycle
+    postgame_linger: float = 0.0
+    max_retries: int = 5
+    retry_delay: float = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Event data model
+# ---------------------------------------------------------------------------
+
+
+class GameEventData(MlbBaseModel):
+    """Payload delivered to callbacks and stream consumers."""
+
+    event_type: GameEvent | str
+    game_pk: int
+    ws_message: WsMessage | None = None
+    feed: LiveFeedResponse | None = None
+    previous_feed: LiveFeedResponse | None = None
+    play: Play | None = None
+    play_event: PlayEvent | None = None
+    start_timecode: str = ""
+    end_timecode: str = ""
+    diff: LiveFeedResponse | None = None
+
+
+# ---------------------------------------------------------------------------
+# Granularity filter
+# ---------------------------------------------------------------------------
+
+# Mapping from FetchGranularity presets to the WS gameEvent values that
+# should trigger a REST fetch.
+_PITCH_TRIGGERS: frozenset[str] = frozenset(
+    {
+        # Pitch results
+        WsGameEvent.BALL,
+        WsGameEvent.CALLED_STRIKE,
+        WsGameEvent.SWINGING_STRIKE,
+        WsGameEvent.FOUL,
+        WsGameEvent.FOUL_TIP,
+        WsGameEvent.FOUL_BUNT,
+        WsGameEvent.BLOCKED_BALL,
+        WsGameEvent.HIT_INTO_PLAY,
+        WsGameEvent.HIT_INTO_PLAY_NO_OUT,
+        WsGameEvent.HIT_INTO_PLAY_SCORE,
+        # Play outcomes
+        WsGameEvent.SINGLE,
+        WsGameEvent.DOUBLE,
+        WsGameEvent.TRIPLE,
+        WsGameEvent.FIELD_OUT,
+        WsGameEvent.STRIKEOUT,
+        WsGameEvent.WALK,
+        WsGameEvent.FORCE_OUT,
+        WsGameEvent.SAC_FLY,
+        WsGameEvent.GROUNDED_INTO_DOUBLE_PLAY,
+        WsGameEvent.CAUGHT_STEALING_2B,
+    }
+)
+
+_PLAY_TRIGGERS: frozenset[str] = frozenset(
+    {
+        # Play completion events
+        WsGameEvent.SINGLE,
+        WsGameEvent.DOUBLE,
+        WsGameEvent.TRIPLE,
+        WsGameEvent.FIELD_OUT,
+        WsGameEvent.STRIKEOUT,
+        WsGameEvent.WALK,
+        WsGameEvent.FORCE_OUT,
+        WsGameEvent.SAC_FLY,
+        WsGameEvent.GROUNDED_INTO_DOUBLE_PLAY,
+        WsGameEvent.CAUGHT_STEALING_2B,
+        # Substitutions
+        WsGameEvent.PITCHING_SUBSTITUTION,
+        WsGameEvent.OFFENSIVE_SUBSTITUTION,
+        WsGameEvent.DEFENSIVE_SWITCH,
+    }
+)
+
+_SCORING_TRIGGERS: frozenset[str] = frozenset(
+    {
+        WsGameEvent.HIT_INTO_PLAY_SCORE,
+    }
+)
+
+
+def _should_fetch(msg: WsMessage, config: LiveGameConfig) -> bool:
+    """Return True if *msg* should trigger a REST fetch given *config*."""
+    granularity = config.granularity
+    events = set(msg.game_events)
+
+    if granularity == FetchGranularity.EVERY_UPDATE:
+        return True
+    if granularity == FetchGranularity.EVERY_PITCH:
+        return bool(events & _PITCH_TRIGGERS)
+    if granularity == FetchGranularity.EVERY_PLAY:
+        return bool(events & _PLAY_TRIGGERS)
+    if granularity == FetchGranularity.SCORING_ONLY:
+        return bool(events & _SCORING_TRIGGERS)
+    if granularity == FetchGranularity.CUSTOM:
+        custom = set(config.custom_triggers)
+        return bool(events & custom) or bool(set(msg.logical_events) & custom)
+    # Unknown granularity — fetch to be safe
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Event detection
+# ---------------------------------------------------------------------------
+
+# Event types that indicate a strikeout
+_STRIKEOUT_EVENTS: frozenset[str] = frozenset(
+    {
+        EventType.STRIKEOUT,
+        EventType.STRIKE_OUT,
+        EventType.STRIKEOUT_DOUBLE_PLAY,
+        EventType.STRIKEOUT_TRIPLE_PLAY,
+    }
+)
+
+_WALK_EVENTS: frozenset[str] = frozenset(
+    {
+        EventType.WALK,
+        EventType.INTENT_WALK,
+    }
+)
+
+
+def _detect_events(
+    old: LiveFeedResponse | None,
+    new: LiveFeedResponse,
+    *,
+    ws_message: WsMessage | None = None,
+    start_timecode: str = "",
+    end_timecode: str = "",
+    diff: LiveFeedResponse | None = None,
+) -> list[GameEventData]:
+    """Compare two feed states and return all detected events."""
+    events: list[GameEventData] = []
+    game_pk = int(new.game_pk)
+
+    def _make(
+        event_type: GameEvent,
+        *,
+        play: Play | None = None,
+        play_event: PlayEvent | None = None,
+    ) -> GameEventData:
+        return GameEventData(
+            event_type=event_type,
+            game_pk=game_pk,
+            ws_message=ws_message,
+            feed=new,
+            previous_feed=old,
+            play=play,
+            play_event=play_event,
+            start_timecode=start_timecode,
+            end_timecode=end_timecode,
+            diff=diff,
+        )
+
+    # Always emit UPDATE
+    events.append(_make(GameEvent.UPDATE))
+
+    # --- Game state changes ---
+    old_state = (
+        old.game_data.status.abstract_game_state
+        if old and old.game_data and old.game_data.status
+        else None
+    )
+    new_state = (
+        new.game_data.status.abstract_game_state
+        if new.game_data and new.game_data.status
+        else None
+    )
+
+    if old_state and new_state and old_state != new_state:
+        events.append(_make(GameEvent.GAME_STATE_CHANGE))
+        if str(new_state) == str(AbstractGameState.LIVE):
+            events.append(_make(GameEvent.GAME_START))
+        elif str(new_state) == str(AbstractGameState.FINAL):
+            events.append(_make(GameEvent.GAME_END))
+
+    new_plays = new.live_data.plays if new.live_data else None
+    old_plays = old.live_data.plays if old and old.live_data else None
+
+    # --- New completed plays ---
+    new_all = new_plays.all_plays if new_plays else []
+    old_all_len = len(old_plays.all_plays) if old_plays else 0
+
+    for play in new_all[old_all_len:]:
+        events.append(_make(GameEvent.PLAY_COMPLETE, play=play))
+
+        event_type = play.result.event_type if play.result else None
+        if event_type:
+            et = str(event_type)
+            if et in _STRIKEOUT_EVENTS:
+                events.append(_make(GameEvent.STRIKEOUT, play=play))
+            elif et in _WALK_EVENTS:
+                events.append(_make(GameEvent.WALK, play=play))
+            elif et == str(EventType.HOME_RUN):
+                events.append(_make(GameEvent.HOME_RUN, play=play))
+
+    # --- New pitches in current play ---
+    new_current = new_plays.current_play if new_plays else None
+    old_current = old_plays.current_play if old_plays else None
+
+    new_events_list = new_current.play_events if new_current else []
+    old_events_len = len(old_current.play_events) if old_current else 0
+
+    # If the current play changed (new at-bat), treat all events as new
+    new_at_bat_idx = new_current.at_bat_index if new_current else None
+    old_at_bat_idx = old_current.at_bat_index if old_current else None
+    if new_at_bat_idx != old_at_bat_idx:
+        old_events_len = 0
+
+    for pe in new_events_list[old_events_len:]:
+        if pe.is_pitch:
+            events.append(_make(GameEvent.PITCH, play=new_current, play_event=pe))
+            if pe.details and pe.details.is_in_play:
+                events.append(_make(GameEvent.HIT, play=new_current, play_event=pe))
+        elif pe.is_substitution:
+            events.append(
+                _make(GameEvent.SUBSTITUTION, play=new_current, play_event=pe)
+            )
+
+    # --- Inning changes ---
+    new_ls = new.live_data.linescore if new.live_data else None
+    old_ls = old.live_data.linescore if old and old.live_data else None
+
+    if new_ls and old_ls:
+        inning_changed = new_ls.current_inning != old_ls.current_inning
+        half_changed = new_ls.inning_half != old_ls.inning_half
+        if inning_changed or half_changed:
+            events.append(_make(GameEvent.INNING_CHANGE))
+
+    # --- Run scored ---
+    if new_ls and old_ls and new_ls.teams and old_ls.teams:
+        new_home_runs = new_ls.teams.home.runs or 0
+        old_home_runs = old_ls.teams.home.runs or 0
+        new_away_runs = new_ls.teams.away.runs or 0
+        old_away_runs = old_ls.teams.away.runs or 0
+        if new_home_runs > old_home_runs or new_away_runs > old_away_runs:
+            events.append(_make(GameEvent.RUN))
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# WebSocket connection
+# ---------------------------------------------------------------------------
+
+
+async def _ws_receive(
+    game_pk: int,
+    config: LiveGameConfig,
+    stop_event: asyncio.Event,
+) -> AsyncIterator[WsMessage]:
+    """Connect to the gameday WebSocket and yield parsed messages.
+
+    Reconnects with exponential backoff on disconnection.
+    """
+    from httpx_ws import aconnect_ws
+
+    url = config.ws_url_template.format(game_pk=game_pk)
+    delay = config.ws_reconnect_delay
+
+    while not stop_event.is_set():
+        try:
+            async with aconnect_ws(url, keepalive_ping_interval_seconds=20) as ws:  # type: ignore[var-annotated]
+                delay = config.ws_reconnect_delay  # reset on success
+                logger.info("WebSocket connected for game %s", game_pk)
+                while not stop_event.is_set():
+                    try:
+                        raw = await asyncio.wait_for(ws.receive_text(), timeout=120)
+                    except asyncio.TimeoutError:
+                        # No message in 120s — keep alive, loop back
+                        continue
+                    try:
+                        msg = WsMessage.model_validate_json(raw)
+                    except Exception:
+                        logger.warning("Unrecognized WS message, skipping: %.200s", raw)
+                        continue
+                    logger.debug(
+                        "WS message: gameEvents=%s logicalEvents=%s ts=%s",
+                        msg.game_events,
+                        msg.logical_events,
+                        msg.time_stamp,
+                    )
+                    yield msg
+        except Exception as exc:
+            if stop_event.is_set():
+                return
+            logger.warning(
+                "WebSocket disconnected (%s), reconnecting in %.1fs",
+                exc,
+                delay,
+            )
+            try:
+                await asyncio.wait_for(stop_event.wait(), timeout=delay)
+                return  # stop was requested during backoff
+            except asyncio.TimeoutError:
+                pass
+            delay = min(delay * 2, config.ws_max_reconnect_delay)
+
+
+# ---------------------------------------------------------------------------
+# REST polling fallback
+# ---------------------------------------------------------------------------
+
+
+async def _rest_poll(
+    game_pk: int,
+    api: AsyncMlbClient,
+    config: LiveGameConfig,
+    stop_event: asyncio.Event,
+    last_feed: LiveFeedResponse | None,
+) -> AsyncIterator[tuple[LiveFeedResponse, str]]:
+    """Poll the REST API for game updates, yielding (feed, timecode) tuples.
+
+    Uses the timestamps endpoint as a change-detection gate to avoid
+    unnecessary full feed fetches.
+    """
+    last_timecode = ""
+
+    while not stop_event.is_set():
+        # Determine poll interval based on game state
+        interval = config.poll_interval
+        if last_feed and last_feed.game_data and last_feed.game_data.status:
+            state = str(last_feed.game_data.status.abstract_game_state or "")
+            if state == str(AbstractGameState.PREVIEW):
+                interval = config.pregame_poll_interval
+            elif state == str(AbstractGameState.FINAL):
+                return
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+            return  # stop was requested
+        except asyncio.TimeoutError:
+            pass
+
+        try:
+            timestamps = await api.game_timestamps(game_pk)
+            ts_list = timestamps.root if hasattr(timestamps, "root") else []
+            current_timecode = ts_list[-1] if ts_list else ""
+
+            if current_timecode and current_timecode == last_timecode:
+                continue  # no change
+
+            last_timecode = current_timecode
+            logger.debug(
+                "REST poll fetch for game %s (timecode=%s)",
+                game_pk,
+                current_timecode,
+            )
+            feed = await api.game(game_pk)
+            last_feed = feed
+            yield feed, current_timecode
+
+        except (MlbApiError, httpx.HTTPError) as exc:
+            logger.warning("REST poll error: %s", exc)
+            continue
+
+
+# ---------------------------------------------------------------------------
+# LiveGameClient (async)
+# ---------------------------------------------------------------------------
+
+# Type alias for async and sync callback signatures
+AsyncHandler = Callable[[GameEventData], Awaitable[None]]
+SyncHandler = Callable[[GameEventData], Any]
+
+
+class LiveGameClient:
+    """Async live game client with WebSocket push and REST enrichment.
+
+    Connects to the MLB gameday WebSocket for real-time push notifications,
+    then optionally fetches full game data via REST based on the configured
+    :class:`FetchGranularity`.
+
+    Parameters
+    ----------
+    game_pk:
+        The MLB game primary key to watch.
+    client:
+        Optional :class:`~mlb_statsapi.AsyncMlbClient` instance for REST
+        calls. If not provided, one is created and managed internally.
+    config:
+        Optional :class:`LiveGameConfig`. Uses defaults if not provided.
+    """
+
+    def __init__(
+        self,
+        game_pk: int,
+        *,
+        client: AsyncMlbClient | None = None,
+        config: LiveGameConfig | None = None,
+    ) -> None:
+        self._game_pk = game_pk
+        self._config = config or LiveGameConfig()
+        self._owns_client = client is None
+        self._api = client or AsyncMlbClient()
+        self._feed: LiveFeedResponse | None = None
+        self._stop = asyncio.Event()
+        self._running = False
+        self._handlers: dict[str, list[AsyncHandler]] = {}
+        self._queues: list[
+            tuple[set[str] | None, asyncio.Queue[GameEventData | None]]
+        ] = []
+        self._last_timecode = ""
+
+    @property
+    def api(self) -> AsyncMlbClient:
+        """The underlying REST client, exposed for enrichment requests."""
+        return self._api
+
+    @property
+    def feed(self) -> LiveFeedResponse | None:
+        """The most recent :class:`LiveFeedResponse`, or ``None``."""
+        return self._feed
+
+    @property
+    def is_running(self) -> bool:
+        """Whether :meth:`watch` is currently active."""
+        return self._running
+
+    @property
+    def game_pk(self) -> int:
+        """The game primary key being watched."""
+        return self._game_pk
+
+    # -- Callback registration --
+
+    def on(
+        self,
+        event_type: GameEvent | str | Sequence[GameEvent | str],
+        handler: AsyncHandler | None = None,
+    ) -> Callable[[AsyncHandler], AsyncHandler]:
+        """Register a callback for one or more event types.
+
+        Can be used as a decorator::
+
+            @client.on(GameEvent.PITCH)
+            async def on_pitch(event: GameEventData): ...
+
+        Or called directly::
+
+            client.on(GameEvent.PITCH, handler=my_handler)
+        """
+        types = [event_type] if isinstance(event_type, str) else list(event_type)
+
+        def _register(fn: AsyncHandler) -> AsyncHandler:
+            for t in types:
+                self._handlers.setdefault(str(t), []).append(fn)
+            return fn
+
+        if handler is not None:
+            _register(handler)
+            return _register
+        return _register
+
+    # -- Async iterator --
+
+    async def stream(
+        self, *event_types: GameEvent | str
+    ) -> AsyncIterator[GameEventData]:
+        """Async iterator yielding :class:`GameEventData` for selected events.
+
+        If no event types are specified, all events are yielded.
+
+        Usage::
+
+            async for event in client.stream(GameEvent.PITCH, GameEvent.RUN):
+                print(event.event_type)
+
+        .. note::
+            Call :meth:`watch` concurrently (e.g. via ``asyncio.create_task``)
+            to drive the event loop.
+        """
+        filter_set: set[str] | None = (
+            {str(t) for t in event_types} if event_types else None
+        )
+        queue: asyncio.Queue[GameEventData | None] = asyncio.Queue()
+        entry = (filter_set, queue)
+        self._queues.append(entry)
+        try:
+            while True:
+                item = await queue.get()
+                if item is None:
+                    break
+                yield item
+        finally:
+            if entry in self._queues:
+                self._queues.remove(entry)
+
+    # -- Lifecycle --
+
+    async def watch(self) -> None:
+        """Watch the game until it ends or :meth:`stop` is called.
+
+        Connects to the WebSocket for push notifications. If the
+        WebSocket is unavailable and ``use_rest_fallback`` is enabled,
+        falls back to REST polling.
+        """
+        self._running = True
+        self._stop.clear()
+        try:
+            # Fetch initial state via REST
+            await self._fetch_initial()
+            # Try WebSocket first
+            try:
+                await self._watch_ws()
+            except Exception as exc:
+                if self._stop.is_set():
+                    return
+                logger.warning("WebSocket failed (%s)", exc)
+                if self._config.use_rest_fallback:
+                    logger.info(
+                        "Falling back to REST polling for game %s", self._game_pk
+                    )
+                    await self._watch_rest()
+                else:
+                    raise
+        finally:
+            self._running = False
+            # Signal stream consumers to stop
+            for _, queue in self._queues:
+                await queue.put(None)
+
+    async def stop(self) -> None:
+        """Signal the watch loop to stop."""
+        self._stop.set()
+
+    async def close(self) -> None:
+        """Stop watching and release resources."""
+        await self.stop()
+        if self._owns_client:
+            await self._api.close()
+
+    async def __aenter__(self) -> LiveGameClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    # -- Internal: initial fetch --
+
+    async def _fetch_initial(self) -> None:
+        """Fetch the initial game state via REST."""
+        retries = 0
+        while not self._stop.is_set():
+            try:
+                self._feed = await self._api.game(self._game_pk)
+                return
+            except (MlbApiError, httpx.HTTPError) as exc:
+                retries += 1
+                if retries > self._config.max_retries:
+                    raise
+                logger.warning(
+                    "Initial fetch failed (%s), retry %d/%d",
+                    exc,
+                    retries,
+                    self._config.max_retries,
+                )
+                try:
+                    await asyncio.wait_for(
+                        self._stop.wait(), timeout=self._config.retry_delay
+                    )
+                    return
+                except asyncio.TimeoutError:
+                    pass
+
+    # -- Internal: WebSocket watch loop --
+
+    async def _watch_ws(self) -> None:
+        """Main watch loop using WebSocket push notifications."""
+        async for msg in _ws_receive(self._game_pk, self._config, self._stop):
+            if self._stop.is_set():
+                return
+
+            # Always emit raw WS_MESSAGE event
+            ws_event = GameEventData(
+                event_type=GameEvent.WS_MESSAGE,
+                game_pk=self._game_pk,
+                ws_message=msg,
+                feed=self._feed,
+                end_timecode=msg.time_stamp,
+                start_timecode=self._last_timecode,
+            )
+            await self._dispatch(ws_event)
+
+            # Check if we should fetch full game data
+            if not _should_fetch(msg, self._config):
+                self._last_timecode = msg.time_stamp
+                continue
+
+            # Fetch full game data via REST
+            try:
+                old_feed = self._feed
+                start_tc = self._last_timecode
+                end_tc = msg.time_stamp
+
+                logger.debug(
+                    "REST fetch triggered for game %s (events=%s)",
+                    self._game_pk,
+                    msg.game_events,
+                )
+                new_feed = await self._api.game(self._game_pk)
+
+                # Optionally fetch diff
+                diff = None
+                if self._config.fetch_diff and start_tc and end_tc:
+                    try:
+                        diff_resp = await self._api.get(
+                            "game_diff",
+                            gamePk=str(self._game_pk),
+                            startTimecode=start_tc,
+                            endTimecode=end_tc,
+                        )
+                        if isinstance(diff_resp, LiveFeedResponse):
+                            diff = diff_resp
+                    except (MlbApiError, httpx.HTTPError) as exc:
+                        logger.warning("game_diff fetch failed: %s", exc)
+
+                # Detect events
+                detected = _detect_events(
+                    old_feed,
+                    new_feed,
+                    ws_message=msg,
+                    start_timecode=start_tc,
+                    end_timecode=end_tc,
+                    diff=diff,
+                )
+
+                self._feed = new_feed
+                self._last_timecode = end_tc
+
+                for event in detected:
+                    await self._dispatch(event)
+
+                # Check for game end
+                if self._is_game_over(new_feed):
+                    if self._config.postgame_linger > 0:
+                        try:
+                            await asyncio.wait_for(
+                                self._stop.wait(),
+                                timeout=self._config.postgame_linger,
+                            )
+                        except asyncio.TimeoutError:
+                            pass
+                    return
+
+            except (MlbApiError, httpx.HTTPError) as exc:
+                logger.warning("REST fetch after WS notification failed: %s", exc)
+                continue
+
+    # -- Internal: REST polling fallback --
+
+    async def _watch_rest(self) -> None:
+        """Fallback watch loop using REST polling."""
+        async for feed, timecode in _rest_poll(
+            self._game_pk, self._api, self._config, self._stop, self._feed
+        ):
+            if self._stop.is_set():
+                return
+
+            old_feed = self._feed
+            start_tc = self._last_timecode
+
+            # Optionally fetch diff
+            diff = None
+            if self._config.fetch_diff and start_tc and timecode:
+                try:
+                    diff_resp = await self._api.get(
+                        "game_diff",
+                        gamePk=str(self._game_pk),
+                        startTimecode=start_tc,
+                        endTimecode=timecode,
+                    )
+                    if isinstance(diff_resp, LiveFeedResponse):
+                        diff = diff_resp
+                except (MlbApiError, httpx.HTTPError) as exc:
+                    logger.warning("game_diff fetch failed: %s", exc)
+
+            detected = _detect_events(
+                old_feed,
+                feed,
+                start_timecode=start_tc,
+                end_timecode=timecode,
+                diff=diff,
+            )
+
+            self._feed = feed
+            self._last_timecode = timecode
+
+            for event in detected:
+                await self._dispatch(event)
+
+            if self._is_game_over(feed):
+                if self._config.postgame_linger > 0:
+                    try:
+                        await asyncio.wait_for(
+                            self._stop.wait(),
+                            timeout=self._config.postgame_linger,
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+                return
+
+    # -- Internal: dispatch --
+
+    async def _dispatch(self, event: GameEventData) -> None:
+        """Dispatch an event to registered handlers and stream queues."""
+        et = str(event.event_type)
+
+        # Fire callbacks
+        handlers = self._handlers.get(et, [])
+        if handlers:
+            logger.debug(
+                "Dispatching %s to %d handler(s) for game %s",
+                et,
+                len(handlers),
+                event.game_pk,
+            )
+        for handler in handlers:
+            try:
+                await handler(event)
+            except Exception:
+                logger.exception("Error in handler for %s", et)
+
+        # Push to stream queues
+        for filter_set, queue in self._queues:
+            if filter_set is None or et in filter_set:
+                await queue.put(event)
+
+    # -- Internal: game over check --
+
+    @staticmethod
+    def _is_game_over(feed: LiveFeedResponse) -> bool:
+        if feed.game_data and feed.game_data.status:
+            state = feed.game_data.status.abstract_game_state
+            return str(state) == str(AbstractGameState.FINAL) if state else False
+        return False
+
+
+# ---------------------------------------------------------------------------
+# SyncLiveGameClient
+# ---------------------------------------------------------------------------
+
+
+class SyncLiveGameClient:
+    """Synchronous live game client.
+
+    Runs an :class:`LiveGameClient` in a background thread. Callbacks
+    registered via :meth:`on` are plain (non-async) functions.
+
+    Usage::
+
+        with SyncLiveGameClient(game_pk=745563) as client:
+
+            @client.on(GameEvent.PITCH)
+            def on_pitch(event: GameEventData):
+                print(f"Pitch: {event.play_event.details.description}")
+
+            client.watch()
+    """
+
+    def __init__(
+        self,
+        game_pk: int,
+        *,
+        config: LiveGameConfig | None = None,
+    ) -> None:
+        self._game_pk = game_pk
+        self._config = config or LiveGameConfig()
+        self._sync_handlers: dict[str, list[SyncHandler]] = {}
+        self._feed: LiveFeedResponse | None = None
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._async_client: LiveGameClient | None = None
+
+    @property
+    def feed(self) -> LiveFeedResponse | None:
+        """The most recent :class:`LiveFeedResponse`, or ``None``."""
+        return self._feed
+
+    @property
+    def game_pk(self) -> int:
+        """The game primary key being watched."""
+        return self._game_pk
+
+    def on(
+        self,
+        event_type: GameEvent | str | Sequence[GameEvent | str],
+        handler: SyncHandler | None = None,
+    ) -> Callable[[SyncHandler], SyncHandler]:
+        """Register a synchronous callback for one or more event types."""
+        types = [event_type] if isinstance(event_type, str) else list(event_type)
+
+        def _register(fn: SyncHandler) -> SyncHandler:
+            for t in types:
+                self._sync_handlers.setdefault(str(t), []).append(fn)
+            return fn
+
+        if handler is not None:
+            _register(handler)
+            return _register
+        return _register
+
+    def watch(self) -> None:
+        """Watch the game until it ends or :meth:`stop` is called.
+
+        Blocks the calling thread.
+        """
+        self._loop = asyncio.new_event_loop()
+        try:
+            self._loop.run_until_complete(self._run())
+        finally:
+            self._loop.close()
+            self._loop = None
+
+    def stop(self) -> None:
+        """Signal the watch loop to stop. Thread-safe."""
+        if self._async_client and self._loop and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._async_client._stop.set)
+
+    def close(self) -> None:
+        """Stop watching and release resources."""
+        self.stop()
+
+    def __enter__(self) -> SyncLiveGameClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    async def _run(self) -> None:
+        """Internal async entry point run in the event loop."""
+        async with LiveGameClient(self._game_pk, config=self._config) as client:
+            self._async_client = client
+
+            # Wrap sync handlers as async and register them
+            for event_type, handlers in self._sync_handlers.items():
+                for sync_fn in handlers:
+
+                    async def _wrapper(
+                        event: GameEventData,
+                        _fn: SyncHandler = sync_fn,
+                    ) -> None:
+                        _fn(event)
+                        # Update feed reference
+                        if event.feed:
+                            self._feed = event.feed
+
+                    client.on(event_type, handler=_wrapper)
+
+            # Also track feed updates for all events
+            async def _track_feed(event: GameEventData) -> None:
+                if event.feed:
+                    self._feed = event.feed
+
+            client.on(GameEvent.UPDATE, handler=_track_feed)
+
+            await client.watch()

--- a/src/mlb_statsapi/models/__init__.py
+++ b/src/mlb_statsapi/models/__init__.py
@@ -92,6 +92,7 @@ from mlb_statsapi.models.stats import (
 from mlb_statsapi.models.teams import Team, TeamsResponse
 from mlb_statsapi.models.transactions import Transaction, TransactionsResponse
 from mlb_statsapi.models.venues import Venue, VenuesResponse
+from mlb_statsapi.models.ws import ChangeEvent, WsGameEvent, WsLogicalEvent, WsMessage
 
 __all__ = [
     # Base & generics
@@ -193,4 +194,9 @@ __all__ = [
     "TransactionsResponse",
     "Venue",
     "VenuesResponse",
+    # WebSocket
+    "ChangeEvent",
+    "WsGameEvent",
+    "WsLogicalEvent",
+    "WsMessage",
 ]

--- a/src/mlb_statsapi/models/ws.py
+++ b/src/mlb_statsapi/models/ws.py
@@ -1,0 +1,180 @@
+"""WebSocket push notification models.
+
+The MLB Stats API pushes lightweight JSON notifications via a WebSocket
+at ``wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/<gamePk>``.
+
+These messages contain event classifications (``logicalEvents``,
+``gameEvents``) and a ``timeStamp`` but **not** full game data. Clients
+use these notifications to decide when to fire REST requests for the
+full game state based on user-configured granularity.
+
+.. note::
+    This WebSocket endpoint is undocumented. The enum values below are
+    based on observed traffic and may be incomplete. All enum-typed fields
+    use the ``EnumType | str`` pattern so that unknown values are accepted.
+"""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """Backport of StrEnum for Python < 3.11."""
+
+
+from mlb_statsapi.models._base import MlbBaseModel
+
+# ---------------------------------------------------------------------------
+# WebSocket event enums — known values, open-ended
+# ---------------------------------------------------------------------------
+
+
+class WsLogicalEvent(StrEnum):
+    """Known ``logicalEvents`` values from the gameday WebSocket.
+
+    These describe logical state changes in the game. The list is
+    non-exhaustive — unknown values are accepted via ``| str``.
+    """
+
+    # Count
+    COUNT_CHANGE = "countChange"
+    COUNT_00 = "count00"
+    COUNT_01 = "count01"
+    COUNT_02 = "count02"
+    COUNT_03 = "count03"
+    COUNT_10 = "count10"
+    COUNT_11 = "count11"
+    COUNT_12 = "count12"
+    COUNT_13 = "count13"
+    COUNT_20 = "count20"
+    COUNT_21 = "count21"
+    COUNT_22 = "count22"
+    COUNT_23 = "count23"
+    COUNT_30 = "count30"
+    COUNT_31 = "count31"
+    COUNT_32 = "count32"
+    COUNT_33 = "count33"
+    COUNT_40 = "count40"
+    COUNT_41 = "count41"
+    COUNT_42 = "count42"
+
+    # Batter
+    NEW_BATTER = "newBatter"
+    NEW_RIGHT_HANDED_HIT = "newRightHandedHit"
+    NEW_LEFT_HANDED_HIT = "newLeftHandedHit"
+    BATTER_SWITCHED_TO_LEFT_HANDED = "batterSwitchedToLeftHanded"
+    BATTER_SWITCHED_TO_RIGHT_HANDED = "batterSwitchedToRightHanded"
+
+    # Baserunners
+    BASES_EMPTY = "basesEmpty"
+    RUNNER_ON_FIRST = "runnerOnFirst"
+    RUNNER_ON_SECOND = "runnerOnSecond"
+    RUNNER_ON_THIRD = "runnerOnThird"
+    RUNNERS_ON_FIRST_AND_SECOND = "runnersOnFirstAndSecond"
+    RUNNERS_ON_FIRST_AND_THIRD = "runnersOnFirstAndThird"
+    RUNNERS_ON_SECOND_AND_THIRD = "runnersOnSecondAndThird"
+    RUNNERS_IN_SCORING_POSITION = "runnersInScoringPosition"
+    BASES_LOADED = "basesLoaded"
+
+    # Inning
+    NEW_HALF_INNING = "newHalfInning"
+    MID_INNING = "midInning"
+
+    # Pitcher
+    PITCHER_CHANGE = "pitcherChange"
+    PITCHER_CHANGE_COMPLETE = "pitcherChangeComplete"
+
+    # Defense
+    DEFENSIVE_SUBSTITUTION = "defensiveSubstitution"
+
+
+class WsGameEvent(StrEnum):
+    """Known ``gameEvents`` values from the gameday WebSocket.
+
+    These describe game-level events. The list is non-exhaustive —
+    unknown values are accepted via ``| str``.
+
+    .. note::
+        Values use **snake_case** (e.g. ``called_strike``, not ``calledStrike``).
+    """
+
+    # Pitches
+    BALL = "ball"
+    CALLED_STRIKE = "called_strike"
+    SWINGING_STRIKE = "swinging_strike"
+    FOUL = "foul"
+    FOUL_TIP = "foul_tip"
+    FOUL_BUNT = "foul_bunt"
+    BLOCKED_BALL = "blocked_ball"
+    HIT_INTO_PLAY = "hit_into_play"
+    HIT_INTO_PLAY_NO_OUT = "hit_into_play_no_out"
+    HIT_INTO_PLAY_SCORE = "hit_into_play_score"
+
+    # Play outcomes
+    SINGLE = "single"
+    DOUBLE = "double"
+    TRIPLE = "triple"
+    FIELD_OUT = "field_out"
+    STRIKEOUT = "strikeout"
+    WALK = "walk"
+    FORCE_OUT = "force_out"
+    SAC_FLY = "sac_fly"
+    GROUNDED_INTO_DOUBLE_PLAY = "grounded_into_double_play"
+    CAUGHT_STEALING_2B = "caught_stealing_2b"
+
+    # Substitutions and other
+    AT_BAT_START = "at_bat_start"
+    PITCHING_SUBSTITUTION = "pitching_substitution"
+    OFFENSIVE_SUBSTITUTION = "offensive_substitution"
+    DEFENSIVE_SWITCH = "defensive_switch"
+    BATTER_TIMEOUT = "batter_timeout"
+    MOUND_VISIT = "mound_visit"
+    GAME_ADVISORY = "game_advisory"
+
+
+# ---------------------------------------------------------------------------
+# WebSocket message model
+# ---------------------------------------------------------------------------
+
+
+class ChangeEvent(MlbBaseModel):
+    """Describes the type of change that triggered the push notification.
+
+    Known ``type`` values: ``new_entry``, ``full_refresh``, ``correction``.
+    Correction events may include ``changed_at_bat_indexes`` indicating
+    which at-bats were modified.
+    """
+
+    type: str | None = None
+    changed_at_bat_indexes: list[int] = []
+
+
+class WsMessage(MlbBaseModel):
+    """A single WebSocket push notification from the gameday feed.
+
+    Example payload::
+
+        {
+            "timeStamp": "20230721_182018",
+            "gamePk": "717325",
+            "updateId": "7a5b0181-f833-4de8-bf1b-65de5e3ef6a3",
+            "wait": 10,
+            "logicalEvents": ["countChange", "count10", "basesEmpty"],
+            "gameEvents": ["ball"],
+            "changeEvent": {"type": "new_entry"},
+        }
+    """
+
+    time_stamp: str
+    game_pk: str
+    update_id: str | None = None
+    wait: int = 10
+    logical_events: list[WsLogicalEvent | str] = []
+    game_events: list[WsGameEvent | str] = []
+    change_event: ChangeEvent | None = None
+    is_delay: bool | None = None

--- a/tests/test_client/test_live.py
+++ b/tests/test_client/test_live.py
@@ -1,0 +1,455 @@
+"""Tests for the live game client."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from mlb_statsapi.client.live import (
+    FetchGranularity,
+    GameEvent,
+    GameEventData,
+    LiveGameClient,
+    LiveGameConfig,
+    SyncLiveGameClient,
+    _detect_events,
+    _should_fetch,
+)
+from mlb_statsapi.models.livefeed import LiveFeedResponse
+from mlb_statsapi.models.ws import WsMessage
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def _load_feed() -> LiveFeedResponse:
+    data = json.loads((FIXTURES_DIR / "livefeed.json").read_text())
+    return LiveFeedResponse.model_validate(data)
+
+
+def _make_ws_message(**overrides: object) -> WsMessage:
+    defaults: dict[str, object] = {
+        "timeStamp": "20240605_200600",
+        "gamePk": "744914",
+        "updateId": "test-id",
+        "wait": 10,
+        "logicalEvents": [],
+        "gameEvents": [],
+    }
+    defaults.update(overrides)
+    return WsMessage.model_validate(defaults)
+
+
+# ---------------------------------------------------------------------------
+# WsMessage model
+# ---------------------------------------------------------------------------
+
+
+class TestWsMessage:
+    def test_parse_minimal(self) -> None:
+        msg = WsMessage.model_validate(
+            {"timeStamp": "20230721_182018", "gamePk": "717325"}
+        )
+        assert msg.time_stamp == "20230721_182018"
+        assert msg.game_pk == "717325"
+        assert msg.wait == 10
+        assert msg.game_events == []
+        assert msg.logical_events == []
+
+    def test_parse_full(self) -> None:
+        msg = WsMessage.model_validate(
+            {
+                "timeStamp": "20230721_182018",
+                "gamePk": "717325",
+                "updateId": "7a5b0181-f833-4de8-bf1b-65de5e3ef6a3",
+                "wait": 10,
+                "logicalEvents": ["countChange", "count10", "basesEmpty"],
+                "gameEvents": ["ball"],
+                "changeEvent": {"type": "new_entry"},
+            }
+        )
+        assert msg.update_id == "7a5b0181-f833-4de8-bf1b-65de5e3ef6a3"
+        assert "countChange" in msg.logical_events
+        assert "ball" in msg.game_events
+        assert msg.change_event is not None
+        assert msg.change_event.type == "new_entry"
+
+    def test_unknown_events_accepted(self) -> None:
+        """Unknown event values should be accepted via | str."""
+        msg = WsMessage.model_validate(
+            {
+                "timeStamp": "20230721_182018",
+                "gamePk": "717325",
+                "gameEvents": ["someFutureEvent"],
+                "logicalEvents": ["unknownLogical"],
+            }
+        )
+        assert "someFutureEvent" in msg.game_events
+        assert "unknownLogical" in msg.logical_events
+
+
+# ---------------------------------------------------------------------------
+# Granularity filter
+# ---------------------------------------------------------------------------
+
+
+class TestGranularityFilter:
+    def test_every_update_always_fetches(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.EVERY_UPDATE)
+        msg = _make_ws_message(gameEvents=[])
+        assert _should_fetch(msg, config) is True
+
+    def test_every_pitch_fetches_on_ball(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.EVERY_PITCH)
+        msg = _make_ws_message(gameEvents=["ball"])
+        assert _should_fetch(msg, config) is True
+
+    def test_every_pitch_fetches_on_called_strike(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.EVERY_PITCH)
+        msg = _make_ws_message(gameEvents=["called_strike"])
+        assert _should_fetch(msg, config) is True
+
+    def test_every_pitch_skips_non_pitch(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.EVERY_PITCH)
+        msg = _make_ws_message(gameEvents=["game_advisory"])
+        assert _should_fetch(msg, config) is False
+
+    def test_every_play_fetches_on_field_out(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.EVERY_PLAY)
+        msg = _make_ws_message(gameEvents=["field_out"])
+        assert _should_fetch(msg, config) is True
+
+    def test_every_play_skips_ball(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.EVERY_PLAY)
+        msg = _make_ws_message(gameEvents=["ball"])
+        assert _should_fetch(msg, config) is False
+
+    def test_scoring_only_fetches_on_hit_into_play_score(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.SCORING_ONLY)
+        msg = _make_ws_message(gameEvents=["hit_into_play_score"])
+        assert _should_fetch(msg, config) is True
+
+    def test_scoring_only_skips_strikeout(self) -> None:
+        config = LiveGameConfig(granularity=FetchGranularity.SCORING_ONLY)
+        msg = _make_ws_message(gameEvents=["strikeout"])
+        assert _should_fetch(msg, config) is False
+
+    def test_custom_triggers_game_events(self) -> None:
+        config = LiveGameConfig(
+            granularity=FetchGranularity.CUSTOM,
+            custom_triggers=["caught_stealing_2b"],
+        )
+        msg = _make_ws_message(gameEvents=["caught_stealing_2b"])
+        assert _should_fetch(msg, config) is True
+
+    def test_custom_triggers_logical_events(self) -> None:
+        config = LiveGameConfig(
+            granularity=FetchGranularity.CUSTOM,
+            custom_triggers=["basesLoaded"],
+        )
+        msg = _make_ws_message(logicalEvents=["basesLoaded"])
+        assert _should_fetch(msg, config) is True
+
+    def test_custom_triggers_no_match(self) -> None:
+        config = LiveGameConfig(
+            granularity=FetchGranularity.CUSTOM,
+            custom_triggers=["caught_stealing_2b"],
+        )
+        msg = _make_ws_message(gameEvents=["ball"])
+        assert _should_fetch(msg, config) is False
+
+
+# ---------------------------------------------------------------------------
+# Event detection
+# ---------------------------------------------------------------------------
+
+
+class TestEventDetection:
+    def test_first_feed_emits_update(self) -> None:
+        feed = _load_feed()
+        events = _detect_events(None, feed)
+        types = {e.event_type for e in events}
+        assert GameEvent.UPDATE in types
+
+    def test_game_state_change_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        # Modify old to be "Live" so transition to "Final" is detected
+        assert old.game_data.status is not None
+        old.game_data.status.abstract_game_state = "Live"
+        events = _detect_events(old, new)
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.GAME_STATE_CHANGE) in types
+        assert str(GameEvent.GAME_END) in types
+
+    def test_game_start_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        assert old.game_data.status is not None
+        assert new.game_data.status is not None
+        old.game_data.status.abstract_game_state = "Preview"
+        new.game_data.status.abstract_game_state = "Live"
+        events = _detect_events(old, new)
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.GAME_START) in types
+
+    def test_new_play_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        assert new.live_data.plays is not None
+        assert old.live_data.plays is not None
+        # Remove last play from old to simulate new play appearing
+        old.live_data.plays.all_plays = old.live_data.plays.all_plays[:-1]
+        events = _detect_events(old, new)
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.PLAY_COMPLETE) in types
+
+    def test_new_pitch_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        assert new.live_data.plays is not None
+        assert new.live_data.plays.current_play is not None
+        assert old.live_data.plays is not None
+        assert old.live_data.plays.current_play is not None
+        # Remove last pitch from old's current play
+        if len(old.live_data.plays.current_play.play_events) > 1:
+            old.live_data.plays.current_play.play_events = (
+                old.live_data.plays.current_play.play_events[:-1]
+            )
+            events = _detect_events(old, new)
+            types = {str(e.event_type) for e in events}
+            assert str(GameEvent.PITCH) in types
+
+    def test_inning_change_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        assert old.live_data.linescore is not None
+        assert new.live_data.linescore is not None
+        old.live_data.linescore.current_inning = 8
+        new.live_data.linescore.current_inning = 9
+        events = _detect_events(old, new)
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.INNING_CHANGE) in types
+
+    def test_half_inning_change_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        assert old.live_data.linescore is not None
+        assert new.live_data.linescore is not None
+        old.live_data.linescore.inning_half = "Top"
+        new.live_data.linescore.inning_half = "Bottom"
+        events = _detect_events(old, new)
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.INNING_CHANGE) in types
+
+    def test_run_scored_detected(self) -> None:
+        old = _load_feed()
+        new = _load_feed()
+        assert old.live_data.linescore is not None
+        assert old.live_data.linescore.teams is not None
+        # Reduce old score so new score looks like a run was scored
+        old.live_data.linescore.teams.home.runs = 0
+        events = _detect_events(old, new)
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.RUN) in types
+
+    def test_no_change_emits_only_update(self) -> None:
+        feed = _load_feed()
+        events = _detect_events(feed, feed)
+        # Same object — no state changes detected beyond UPDATE
+        types = {str(e.event_type) for e in events}
+        assert str(GameEvent.UPDATE) in types
+        assert str(GameEvent.GAME_STATE_CHANGE) not in types
+        assert str(GameEvent.PLAY_COMPLETE) not in types
+        assert str(GameEvent.INNING_CHANGE) not in types
+        assert str(GameEvent.RUN) not in types
+
+    def test_event_data_carries_timecodes(self) -> None:
+        feed = _load_feed()
+        events = _detect_events(
+            None,
+            feed,
+            start_timecode="20240605_200000",
+            end_timecode="20240605_200600",
+        )
+        assert events[0].start_timecode == "20240605_200000"
+        assert events[0].end_timecode == "20240605_200600"
+
+    def test_event_data_carries_ws_message(self) -> None:
+        feed = _load_feed()
+        msg = _make_ws_message(gameEvents=["ball"])
+        events = _detect_events(None, feed, ws_message=msg)
+        assert events[0].ws_message is msg
+
+    def test_event_data_carries_diff(self) -> None:
+        feed = _load_feed()
+        diff_feed = _load_feed()
+        events = _detect_events(None, feed, diff=diff_feed)
+        assert events[0].diff is diff_feed
+
+
+# ---------------------------------------------------------------------------
+# LiveGameClient
+# ---------------------------------------------------------------------------
+
+
+class TestLiveGameClient:
+    def test_callback_registration(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+
+        called = []
+
+        @client.on(GameEvent.PITCH)
+        async def handler(event: GameEventData) -> None:
+            called.append(event)
+
+        assert str(GameEvent.PITCH) in client._handlers
+        assert len(client._handlers[str(GameEvent.PITCH)]) == 1
+
+    def test_multi_event_registration(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+
+        @client.on([GameEvent.PITCH, GameEvent.HIT])
+        async def handler(event: GameEventData) -> None:
+            pass
+
+        assert str(GameEvent.PITCH) in client._handlers
+        assert str(GameEvent.HIT) in client._handlers
+
+    def test_direct_handler_registration(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+
+        async def handler(event: GameEventData) -> None:
+            pass
+
+        client.on(GameEvent.RUN, handler=handler)
+        assert len(client._handlers[str(GameEvent.RUN)]) == 1
+
+    def test_properties(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+        assert client.game_pk == 744914
+        assert client.feed is None
+        assert client.is_running is False
+
+    @pytest.mark.asyncio
+    async def test_dispatch_fires_callbacks(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+        received: list[GameEventData] = []
+
+        @client.on(GameEvent.UPDATE)
+        async def handler(event: GameEventData) -> None:
+            received.append(event)
+
+        event = GameEventData(
+            event_type=GameEvent.UPDATE,
+            game_pk=744914,
+        )
+        await client._dispatch(event)
+        assert len(received) == 1
+        assert received[0].event_type == GameEvent.UPDATE
+
+    @pytest.mark.asyncio
+    async def test_dispatch_pushes_to_stream_queue(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+        queue: asyncio.Queue[GameEventData | None] = asyncio.Queue()
+        client._queues.append(({str(GameEvent.PITCH)}, queue))
+
+        # Should be pushed (matches filter)
+        pitch_event = GameEventData(event_type=GameEvent.PITCH, game_pk=744914)
+        await client._dispatch(pitch_event)
+        assert not queue.empty()
+        item = await queue.get()
+        assert item is not None
+        assert item.event_type == GameEvent.PITCH
+
+        # Should NOT be pushed (doesn't match filter)
+        run_event = GameEventData(event_type=GameEvent.RUN, game_pk=744914)
+        await client._dispatch(run_event)
+        assert queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_dispatch_no_filter_gets_all(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+        queue: asyncio.Queue[GameEventData | None] = asyncio.Queue()
+        client._queues.append((None, queue))  # None = no filter
+
+        event = GameEventData(event_type=GameEvent.SUBSTITUTION, game_pk=744914)
+        await client._dispatch(event)
+        assert not queue.empty()
+
+    @pytest.mark.asyncio
+    async def test_handler_error_does_not_crash(self) -> None:
+        client = LiveGameClient(game_pk=744914)
+
+        @client.on(GameEvent.UPDATE)
+        async def bad_handler(event: GameEventData) -> None:
+            raise ValueError("boom")
+
+        event = GameEventData(event_type=GameEvent.UPDATE, game_pk=744914)
+        # Should not raise
+        await client._dispatch(event)
+
+    @pytest.mark.asyncio
+    async def test_is_game_over(self) -> None:
+        feed = _load_feed()
+        assert LiveGameClient._is_game_over(feed) is True
+
+        assert feed.game_data.status is not None
+        feed.game_data.status.abstract_game_state = "Live"
+        assert LiveGameClient._is_game_over(feed) is False
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self) -> None:
+        async with LiveGameClient(game_pk=744914) as client:
+            assert client.game_pk == 744914
+
+
+# ---------------------------------------------------------------------------
+# SyncLiveGameClient
+# ---------------------------------------------------------------------------
+
+
+class TestSyncLiveGameClient:
+    def test_callback_registration(self) -> None:
+        client = SyncLiveGameClient(game_pk=744914)
+
+        @client.on(GameEvent.PITCH)
+        def handler(event: GameEventData) -> None:
+            pass
+
+        assert str(GameEvent.PITCH) in client._sync_handlers
+
+    def test_properties(self) -> None:
+        client = SyncLiveGameClient(game_pk=744914)
+        assert client.game_pk == 744914
+        assert client.feed is None
+
+    def test_context_manager(self) -> None:
+        with SyncLiveGameClient(game_pk=744914) as client:
+            assert client.game_pk == 744914
+
+
+# ---------------------------------------------------------------------------
+# Config model
+# ---------------------------------------------------------------------------
+
+
+class TestLiveGameConfig:
+    def test_defaults(self) -> None:
+        config = LiveGameConfig()
+        assert config.granularity == FetchGranularity.EVERY_PITCH
+        assert config.poll_interval == 10.0
+        assert config.fetch_diff is False
+        assert config.use_rest_fallback is True
+
+    def test_custom_config(self) -> None:
+        config = LiveGameConfig(
+            granularity=FetchGranularity.SCORING_ONLY,
+            fetch_diff=True,
+            poll_interval=5.0,
+        )
+        assert config.granularity == FetchGranularity.SCORING_ONLY
+        assert config.fetch_diff is True
+        assert config.poll_interval == 5.0


### PR DESCRIPTION
## Summary

Closes #25

- Add `LiveGameClient` (async) and `SyncLiveGameClient` (sync) for watching MLB games in real time via the gameday WebSocket at `wss://ws.statsapi.mlb.com/api/v1/game/push/subscribe/gameday/<gamePk>`
- Configurable fetch granularity (`EVERY_UPDATE`, `EVERY_PITCH`, `EVERY_PLAY`, `SCORING_ONLY`, `CUSTOM`) controls when WebSocket notifications trigger REST fetches for full game data
- Callback/decorator and async iterator (`stream()`) consumption patterns
- Event detection by comparing consecutive `LiveFeedResponse` states (pitch, hit, play complete, run, inning change, substitution, game start/end)
- REST polling fallback when WebSocket is unavailable
- WebSocket message model (`WsMessage`) with enum values based on observed live game traffic
- Debug logging for WS messages, REST fetches, and callback dispatch

### New files
- `src/mlb_statsapi/client/live.py` — client implementation (988 lines)
- `src/mlb_statsapi/models/ws.py` — WebSocket message model and event enums
- `tests/test_client/test_live.py` — 41 unit tests
- `examples/live_game.py` — example usage
- `docs/live-game-client.md` — full documentation

### Modified files
- `pyproject.toml` — added `httpx-ws>=0.6` dependency
- `src/mlb_statsapi/__init__.py` — exports live client classes
- `src/mlb_statsapi/models/__init__.py` — exports WS model classes
- `README.md` — added live game section and updated features list

## Test plan

- [x] `pytest tests/test_client/test_live.py` — 41 tests pass
- [x] `pytest` — full suite (337 tests) passes with no regressions
- [x] `ruff check` — clean
- [x] `mypy` — clean
- [ ] Manual integration test against a live game

🤖 Generated with [Claude Code](https://claude.com/claude-code)